### PR TITLE
<ga-auth> Tag is never closed

### DIFF
--- a/site/6-pure-html-dashboards.html
+++ b/site/6-pure-html-dashboards.html
@@ -20,7 +20,7 @@
       <a href="/">Embed API Demos</a>
       <em>Pure HTML Dashboards</em>
     </h1>
-    <ga-auth clientid="623325626209-j1jm9d78ge0v4uf8b9cor31qsirungrq.apps.googleusercontent.com"></gauth>
+    <ga-auth clientid="623325626209-j1jm9d78ge0v4uf8b9cor31qsirungrq.apps.googleusercontent.com"></ga-auth>
   </header>
 
   <ga-dashboard>


### PR DESCRIPTION
Opens <ga-auth> and closes <gauth>. Just a small style issue.
