### PR TITLE
Add feature to expand Custom Segment definitions.

### DIFF
--- a/assets/css/vendor/explorer.css
+++ b/assets/css/vendor/explorer.css
@@ -406,6 +406,13 @@ button.submitBtn:hover span, button.submitBtnHover span {
 
 }
 
+/* links within drop down rows like the segment expander */
+.dd-row-link {
+    float: right;
+    text-align: right;
+    padding-right: 5px;
+}
+
 /* indent for the account and segments dropdown */
 .dd-item, #segment-dd .dd-row {
   padding: 2px 0 2px 15px;

--- a/assets/javascript/explorer/ga-dropdown.js
+++ b/assets/javascript/explorer/ga-dropdown.js
@@ -551,7 +551,7 @@ explorer.SegmentsDropdown.prototype.updateDropdown = function() {
       var expand_link = '';
       var segment_id = segments.values[segment];
       if (segment_id.constructor === Array) {
-          segment_id = segments.values[segment][0]
+          segment_id = segments.values[segment][0];
           definition_attr = ' definition="' + segments.values[segment][1] + '"';
           expand_link = '<a class=dd-row-link name=expand_link>Expand</a>';
       }
@@ -616,11 +616,10 @@ explorer.SegmentsDropdown.prototype.updateValues = function(results) {
 explorer.SegmentsDropdown.prototype.addRowHandlers = function() {
   var self = this;
   $('#' + this.dropdown.id + ' .dd-row')
-    .click(function(e) {;
+    .click(function(e) {
+        var segmentTxt = $(this).attr('id');
         if (e.target.name == 'expand_link') {
-          var segmentTxt = $(this).attr('definition');
-        } else {
-          var segmentTxt = $(this).attr('id');
+          segmentTxt = $(this).attr('definition');
         }
 
         // update input value and fire keyup to update query object

--- a/assets/javascript/explorer/ga-dropdown.js
+++ b/assets/javascript/explorer/ga-dropdown.js
@@ -552,8 +552,10 @@ explorer.SegmentsDropdown.prototype.updateDropdown = function() {
       var segment_id = segments.values[segment];
       if (segment_id.constructor === Array) {
           segment_id = segments.values[segment][0];
-          definition_attr = ' definition="' + segments.values[segment][1] + '"';
-          expand_link = '<a class=dd-row-link name=expand_link>Expand</a>';
+          if (segments.values[segment][1] !== '') {
+            definition_attr = ' definition="' + segments.values[segment][1] + '"';
+            expand_link = '<a class=dd-row-link name=expand_link>Expand</a>';
+          }
       }
       html.push([
         '<div class="dd-row"', definition_attr,

--- a/assets/javascript/explorer/ga-dropdown.js
+++ b/assets/javascript/explorer/ga-dropdown.js
@@ -547,9 +547,19 @@ explorer.SegmentsDropdown.prototype.updateDropdown = function() {
     // Add the segment names.
     var segments = this.values[groupName];
     for (var segment in segments.values) {
+      var definition_attr = '';
+      var expand_link = '';
+      var segment_id = segments.values[segment];
+      if (segment_id.constructor === Array) {
+          segment_id = segments.values[segment][0]
+          definition_attr = ' definition="' + segments.values[segment][1] + '"';
+          expand_link = '<a class=dd-row-link name=expand_link>Expand</a>';
+      }
       html.push([
-        '<div class="dd-row" id="', segments.values[segment], '">',
+        '<div class="dd-row"', definition_attr,
+        ' id="', segment_id, '">',
         explorer.util.htmlEscape(segment),
+        expand_link,
         '</div>'
       ].join(''));
     }
@@ -583,7 +593,7 @@ explorer.SegmentsDropdown.prototype.updateValues = function(results) {
       // we use anything that is not a number or > -1.
       var segmentId = parseInt(segment.id, 10);
       if (!segmentId || (segmentId >= -1)) {
-        customSegments[segment.name] = segment.segmentId;
+        customSegments[segment.name] = [segment.segmentId, segment.definition];
         hasCustomSegments = true;
       }
     }
@@ -606,8 +616,12 @@ explorer.SegmentsDropdown.prototype.updateValues = function(results) {
 explorer.SegmentsDropdown.prototype.addRowHandlers = function() {
   var self = this;
   $('#' + this.dropdown.id + ' .dd-row')
-    .click(function() {
-        var segmentTxt = $(this).attr('id');
+    .click(function(e) {;
+        if (e.target.name == 'expand_link') {
+          var segmentTxt = $(this).attr('definition');
+        } else {
+          var segmentTxt = $(this).attr('id');
+        }
 
         // update input value and fire keyup to update query object
         $(self.input).val(segmentTxt).keyup();

--- a/assets/javascript/explorer/ga-values.js
+++ b/assets/javascript/explorer/ga-values.js
@@ -89,7 +89,8 @@ explorer.queryConfig = {
     'req': false,
     'help': 'Specifies a subset of visits based on either an expression or a ' +
         'filter. The subset of visits matched happens before dimensions ' +
-        'and metrics are calculated.',
+        'and metrics are calculated. For Custom Segments, click the "Expand" ' +
+        'link to use the segment defintion rather than the id.',
     'example': 'Dynamic: <em>segment=</em>dynamic::ga:source=~twitter<br/>By ' +
         'ID: <em>segment=</em>gaid::-3',
     'anchor': '#segment'},


### PR DESCRIPTION
I originally mentioned this feature in an email to grano. At times, it is necessary to create an API request using the full segment defintion (e.g. when the user that will be executing the query doesn't have the segment defined.) This hack makes it possible to insert the segment definition into the builder rather than just the id.