### PR TITLE
Exclude ga:calcMetrics_<NAME> until it's fully supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp-util": "^3.0.6",
     "highlight.js": "^9.0.0",
     "imagemin-pngquant": "^4.2.0",
-    "javascript-api-utils": "googleanalytics/javascript-api-utils#0.5.0",
+    "javascript-api-utils": "googleanalytics/javascript-api-utils#0.6.0",
     "jquery": "^2.1.4",
     "lodash": "^4.0.0",
     "material-design-icons": "^2.1.3",

--- a/src/javascript/query-explorer/actions/select2-options.js
+++ b/src/javascript/query-explorer/actions/select2-options.js
@@ -139,11 +139,15 @@ function getSegmentsOptions(useDefinition) {
  * @return {Promise} A promise resolved with an array of all public metrics.
  */
 function getMetrics(account, property, view) {
-  return metadata.getAuthenticated(account, property, view).then(
-      (columns) => columns.allMetrics({
-        status: 'PUBLIC',
-        addedInApiVersion: '3'
-      }));
+  return metadata.getAuthenticated(account, property, view).then((columns) => {
+    return columns.allMetrics((metric, id) => {
+      return metric.status == 'PUBLIC' &&
+             metric.addedInApiVersion == '3' &&
+             // TODO(philipwalton): remove this temporary exclusion once
+             // calulated metrics can be templatized using the Management API.
+             id != 'ga:calcMetric_<NAME>'
+    });
+  });
 }
 
 
@@ -155,9 +159,10 @@ function getMetrics(account, property, view) {
  * @return {Promise} A promise resolved with an array of all public dimensions.
  */
 function getDimensions(account, property, view) {
-  return metadata.getAuthenticated(account, property, view).then(
-      (columns) => columns.allDimensions({
-        status: 'PUBLIC',
-        addedInApiVersion: '3'
-      }));
+  return metadata.getAuthenticated(account, property, view).then((columns) => {
+    return columns.allDimensions({
+      status: 'PUBLIC',
+      addedInApiVersion: '3'
+    });
+  });
 }


### PR DESCRIPTION
Until we can properly templatize exactly what calculated metrics are available to the currently authorized user, we need to exclude the `ga:calcMetric_<NAME>` result from the metadata API.

Note: Here are the [updates](https://github.com/googleanalytics/javascript-api-utils/commit/8fcd93ae9f3dee3df5a39dcd85f60e2624990a0e) I made to the [javascript-api-utils](https://github.com/googleanalytics/javascript-api-utils) module to make this work here.