### PR TITLE
Update the third-party visualization demo styling

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -63,18 +63,16 @@ gulp.task('css', function() {
 
 gulp.task('images', function() {
   return merge(
-    gulp.src('src/images/**/*.svg')
-        .pipe(gulp.dest('public/images')),
-
-    gulp.src('src/images/**/*.png')
-        .pipe(imagemin({use: [pngquant()]}))
-        .pipe(gulp.dest('public/images')),
-
-    gulp.src('src/images/**/*.png')
-        .pipe(resize({width : '50%'}))
-        .pipe(imagemin({use: [pngquant()]}))
-        .pipe(rename((p) => p.basename = p.basename.replace('-2x', '')))
-        .pipe(gulp.dest('public/images'))
+      gulp.src('src/images/**/*.svg')
+          .pipe(gulp.dest('public/images')),
+      gulp.src('src/images/**/*.png')
+          .pipe(imagemin({use: [pngquant()]}))
+          .pipe(gulp.dest('public/images')),
+      gulp.src('src/images/**/*.png')
+          .pipe(resize({width : '50%'}))
+          .pipe(imagemin({use: [pngquant()]}))
+          .pipe(rename((p) => p.basename = p.basename.replace('-2x', '')))
+          .pipe(gulp.dest('public/images'))
   );
 });
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -54,10 +54,16 @@ gulp.task('css', function() {
     compress: isProd(),
     url: {url: 'inline'}
   }
-  return gulp.src('./src/css/index.css')
-      .pipe(plumber({errorHandler: streamError}))
-      .pipe(cssnext(opts))
-      .pipe(gulp.dest('public/css'));
+  return merge(
+      gulp.src('./src/css/index.css')
+          .pipe(plumber({errorHandler: streamError}))
+          .pipe(cssnext(opts))
+          .pipe(gulp.dest('public/css')),
+      gulp.src('./src/css/chartjs-visualizations.css')
+          .pipe(plumber({errorHandler: streamError}))
+          .pipe(cssnext(opts))
+          .pipe(gulp.dest('public/css'))
+  );
 });
 
 

--- a/src/css/chartjs-visualizations.css
+++ b/src/css/chartjs-visualizations.css
@@ -1,0 +1,24 @@
+/*
+Copyright 2016 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Base styles, media queries, variables, etc. */
+@import './base/custom-media';
+@import './base/variables';
+
+
+/* Components. */
+@import './components/active-users';
+@import './components/chartjs';

--- a/src/css/components/active-users.css
+++ b/src/css/components/active-users.css
@@ -15,12 +15,6 @@ limitations under the License.
 */
 
 
-@import './site';
-
-/**
- * ActiveUsers Component
- */
-
 .ActiveUsers {
   background: var(--bg-color-light);
   border: 1px solid var(--border-color);

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -31,13 +31,11 @@ limitations under the License.
 /* Components. */
 @import './components/account-explorer-results';
 @import './components/account-explorer-search';
-@import './components/active-users';
 @import './components/alert';
 @import './components/alert-dispatcher';
 @import './components/box';
 @import './components/button';
 @import './components/button-set';
-@import './components/chartjs';
 @import './components/checkbox';
 @import './components/content';
 @import './components/dashboard';

--- a/templates/embed-api/dependencies/_third-party-visualizations.html
+++ b/templates/embed-api/dependencies/_third-party-visualizations.html
@@ -11,3 +11,6 @@
 
 <!-- Include the ActiveUsers component script. -->
 <script src="/public/javascript/embed-api/components/active-users.js"></script>
+
+<!-- Include the CSS that styles the charts. -->
+<link rel="stylesheet" href="/public/css/chartjs-visualizations.css">

--- a/templates/embed-api/third-party-visualizations.html
+++ b/templates/embed-api/third-party-visualizations.html
@@ -50,9 +50,9 @@
     <li class="FlexGrid-item">
       <div class="Chartjs">
         <header class="Titles">
-        <h1 class="Titles-main">Top Browsers</h1>
-        <div class="Titles-sub">By pageview</div>
-      </header>
+          <h1 class="Titles-main">Top Browsers</h1>
+          <div class="Titles-sub">By pageview</div>
+        </header>
         <figure class="Chartjs-figure" id="chart-3-container"></figure>
         <ol class="Chartjs-legend" id="legend-3-container"></ol>
       </div>
@@ -73,7 +73,7 @@
 <section>
 <h2>How it works</h2>
 
-<p>You can recreate the demo above by copy and pasting the following code into an HTML file running on a web server. Feel free to add some CSS to spice it up a bit!</p>
+<p>You can recreate the demo above by copy and pasting the following code into an HTML file running on a web server. Feel free to add additional CSS to spice it up a bit!</p>
 
 <p>If you want to know more, check out the <a href="https://developers.google.com/analytics/devguides/reporting/embed/">Embed API documentation</a> on our developers site.</p>
 
@@ -91,17 +91,32 @@
 
 <pre>
 {%- filter forceescape -%}
-<div id="embed-api-auth-container"></div>
-<div id="view-selector-container"></div>
-<div id="active-users-container"></div>
-<div id="chart-1-container"></div>
-<div id="legend-1-container"></div>
-<div id="chart-2-container"></div>
-<div id="legend-2-container"></div>
-<div id="chart-3-container"></div>
-<div id="legend-3-container"></div>
-<div id="chart-4-container"></div>
-<div id="legend-4-container"></div>
+<header>
+  <div id="embed-api-auth-container"></div>
+  <div id="view-selector-container"></div>
+  <div id="view-name"></div>
+  <div id="active-users-container"></div>
+</header>
+<div class="Chartjs">
+  <h3>This Week vs Last Week (by sessions)</h3>
+  <figure class="Chartjs-figure" id="chart-1-container"></figure>
+  <ol class="Chartjs-legend" id="legend-1-container"></ol>
+</div>
+<div class="Chartjs">
+  <h3>This Year vs Last Year (by users)</h3>
+  <figure class="Chartjs-figure" id="chart-2-container"></figure>
+  <ol class="Chartjs-legend" id="legend-2-container"></ol>
+</div>
+<div class="Chartjs">
+  <h3>Top Browsers (by pageview)</h3>
+  <figure class="Chartjs-figure" id="chart-3-container"></figure>
+  <ol class="Chartjs-legend" id="legend-3-container"></ol>
+</div>
+<div class="Chartjs">
+  <h3>Top Countries (by sessions)</h3>
+  <figure class="Chartjs-figure" id="chart-4-container"></figure>
+  <ol class="Chartjs-legend" id="legend-4-container"></ol>
+</div>
 {%- endfilter -%}
 </pre>
 


### PR DESCRIPTION
Fixes #51 by extracting the CSS needed to replicate the Chart.js visualizations into its own file that can be linked to in a standalone demo.