### PR TITLE
Skip SDK update checks for dev_appserver.py

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -276,7 +276,7 @@ gulp.task('test', ['lint'], function() {
 
 
 gulp.task('serve', [], function(done) {
-  devServer = spawn('dev_appserver.py', ['.']);
+  devServer = spawn('dev_appserver.py', [ '--skip_sdk_update_check', '1', '.']);
   devServer.stderr.on('data', (data) => {
     if (data.includes('Starting module')) done();
     process.stdout.write(data);


### PR DESCRIPTION
Without this (or a configured `~/.appcfg_nag`), a non-echoed prompt for `Allow dev_appserver to check for updates on startup? (Y/n):` blocks the `gulp serve` task, and running `npm start` will hang after
```
[15:46:00] Starting 'build:core'...
[15:46:00] Finished 'build:core' after 9.96 μs
```