### PR TITLE
Cohort Request Composer now supports segments

### DIFF
--- a/src/javascript/request-composer/components/cohort-table.js
+++ b/src/javascript/request-composer/components/cohort-table.js
@@ -41,8 +41,8 @@ function tablizeCohortReportData(report, cohortSize) {
 
   const cohortColumnIndex = report.columnHeader.dimensions.indexOf('ga:cohort');
   if (cohortColumnIndex === -1) {
-throw new Error('Report data doesn\'t include a cohort column!');
-}
+    throw new Error('Report data doesn\'t include a cohort column!');
+  }
 
   if (report.data.rows && report.data.rows.length) {
     for (let row of report.data.rows) {

--- a/src/javascript/request-composer/components/cohort-table.js
+++ b/src/javascript/request-composer/components/cohort-table.js
@@ -39,12 +39,16 @@ function tablizeCohortReportData(report, cohortSize) {
     headers.push(`${cohortSize} ${i}`);
   }
 
+  const cohortColumnIndex = report.columnHeader.dimensions.indexOf('ga:cohort')
+  if(cohortColumnIndex === -1)
+    throw new Error("Report data doesn't include a cohort column!")
+
   if (report.data.rows && report.data.rows.length) {
     for (let row of report.data.rows) {
-      if (row.dimensions && row.dimensions.length == 2) {
-        let rowKey = row.dimensions[0];
+      if (row.dimensions && row.dimensions.length > cohortColumnIndex) {
+        let rowKey = row.dimensions[cohortColumnIndex];
 
-        if (rowKey != currentDataRow[0]) {
+        if (rowKey != currentDataRow[cohortColumnIndex]) {
           currentDataRow = [];
           dataRows.push(currentDataRow);
           currentDataRow[0] = rowKey;

--- a/src/javascript/request-composer/components/cohort-table.js
+++ b/src/javascript/request-composer/components/cohort-table.js
@@ -39,9 +39,10 @@ function tablizeCohortReportData(report, cohortSize) {
     headers.push(`${cohortSize} ${i}`);
   }
 
-  const cohortColumnIndex = report.columnHeader.dimensions.indexOf('ga:cohort')
-  if(cohortColumnIndex === -1)
-    throw new Error("Report data doesn't include a cohort column!")
+  const cohortColumnIndex = report.columnHeader.dimensions.indexOf('ga:cohort');
+  if (cohortColumnIndex === -1) {
+throw new Error('Report data doesn\'t include a cohort column!');
+}
 
   if (report.data.rows && report.data.rows.length) {
     for (let row of report.data.rows) {

--- a/src/javascript/request-composer/request.js
+++ b/src/javascript/request-composer/request.js
@@ -195,7 +195,7 @@ function applyDimensions(request, params, settings) {
  * @return {Object} The Report Request object.
  */
 function applySegment(request, params, settings) {
-  if (settings.requestType != 'COHORT' && params.segment) {
+  if (/*settings.requestType != 'COHORT' && */params.segment) {
     request.segments = [{segmentId: params.segment}];
 
     // Get current dimensions if they exist otherwise empty list.

--- a/src/javascript/request-composer/request.js
+++ b/src/javascript/request-composer/request.js
@@ -195,7 +195,7 @@ function applyDimensions(request, params, settings) {
  * @return {Object} The Report Request object.
  */
 function applySegment(request, params, settings) {
-  if (/*settings.requestType != 'COHORT' && */params.segment) {
+  if (params.segment) {
     request.segments = [{segmentId: params.segment}];
 
     // Get current dimensions if they exist otherwise empty list.


### PR DESCRIPTION
Fixes #317 

Currently, if you try to add a segment to a Cohort Request in the Request Composer, it doesn't do anything. There are two bugs that this fixes:

- There is logic in the Request Builder that prevents segments from being added if this is a cohort request
- There is a bug in the data tabularizer that prevents the data from being rendered correctly if the request is a segment request.

Both of these issues are fixed. The linked bug (#317) catalogues my research into this issue, including the relevant commits related to cohorts + segments. In particular, it appears that segments were added, then removed, then added again, then *removed* again, and then the UI element was re-enabled but the logic was still preventing segments from being combined with cohorts.