### PR TITLE
Fixed layout of meta.yaml

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -75,8 +75,7 @@ projects:
   - analyticsjs
   - ecjs
   external:
-    action: View Demo
-    url: https://enhancedecommerce.appspot.com
+    action: View Demo url: https://enhancedecommerce.appspot.com
 - title: Hit Builder
   type: tool
   slug: hit-builder
@@ -94,15 +93,27 @@ projects:
 - title: Query Explorer
   type: tool
   slug: query-explorer
-  tech: [core_reporting_api, embed_api, management_api, metadata_api]
+  tech:
+  - core_reporting_api
+  - embed_api
+  - management_api
+  - metadata_api
 - title: Request Composer
   type: tool
   slug: request-composer
-  tech: [analytics_reporting_api_v4, embed_api, management_api, metadata_api]
+  tech:
+  - analytics_reporting_api_v4
+  - embed_api
+  - management_api
+  - metadata_api
 - title: Spreadsheet Add-on
   type: tool
   slug: spreadsheet-add-on
-  tech: [core_reporting_api, management_api, mcf_reporting_api, metadata_api]
+  tech:
+  - core_reporting_api
+  - management_api
+  - mcf_reporting_api
+  - metadata_api
   external:
     action: Get Add-on
     url: https://chrome.google.com/webstore/detail/google-analytics/fefimfimnhjjkomigakinmjileehfopp

--- a/meta.yaml
+++ b/meta.yaml
@@ -68,11 +68,6 @@ projects:
     - embed_api
     - api_client_library_python
     excerpt: 'This demo shows how you can use server-side authorization to display your Google Analytics data to users without granting them access to your Google Analytics account.'
-- title: Dimensions and Metrics Explorer
-  type: tool
-  slug: dimensions-metrics-explorer
-  tech:
-
 - title: Enhanced Ecommerce
   type: demo
   slug: enhanced-ecommerce

--- a/meta.yaml
+++ b/meta.yaml
@@ -11,11 +11,15 @@ projects:
 - title: Autotrack
   type: demo
   slug: autotrack
-  tech: [autotrack, embed_api]
+  tech:
+  - autotrack
+  - embed_api
 - title: Account Explorer
   type: tool
   slug: account-explorer
-  tech: [embed_api, management_api]
+  tech:
+  - embed_api
+  - management_api
 - title: Campaign URL Builder
   type: tool
   slug: campaign-url-builder
@@ -26,50 +30,69 @@ projects:
   external:
     action: Launch Tool
     url: https://developers.google.com/analytics/devguides/reporting/core/dimsmets
-  tech: [metadata_api]
+  tech:
+  - metadata_api
 - title: Embed API
   type: demo
   slug: embed-api
   pages:
   - title: Basic Dashboard
     slug: basic-dashboard
-    tech: [embed_api]
+    tech:
+    - embed_api
     excerpt: 'This demos shows how to create a basic dashboard with a single timeline chart showing site traffic over the past week. You can update the chart to see data for any Google Analytics view you have access to.'
   - title: Multiple Views
     slug: multiple-views
-    tech: [embed_api]
+    tech:
+    - embed_api
     excerpt: 'Displaying two different views side-by-side is not currently possible through the Google Analytics website. This demo shows how easy it is to do this using the Embed API.'
   - title: Interactive Charts
     slug: interactive-charts
-    tech: [embed_api]
+    tech:
+    - embed_api
     excerpt: 'This demo shows how you can build a dashboard that allows you to interactively explore your data. In this example you have a list of filters in one chart that you can click on and then a second chart will render showing just that filtered dataset.'
   - title: Working with Custom Components
     slug: custom-components
-    tech: [embed_api]
+    tech:
+    - embed_api
     excerpt: 'The built-in components that ship with the Embed API are very nice, but sometimes you need to do more. This example shows how you can extend the Embed API to use your own custom components.'
   - title: Third Party Visualizations
     slug: third-party-visualizations
-    tech: [embed_api, real_time_reporting_api]
+    tech:
+    - embed_api
+    - real_time_reporting_api
     excerpt: 'The Embed API make it easy to query data and display it in a Google Chart. But it also allows you to access the raw data so you can display it however you want. This example uses the <a href="http://www.chartjs.org/">Chart.js</a> visualization library.'
   - title: Server-side Authorization
     slug: server-side-authorization
-    tech: [embed_api, api_client_library_python]
+    tech:
+    - embed_api
+    - api_client_library_python
     excerpt: 'This demo shows how you can use server-side authorization to display your Google Analytics data to users without granting them access to your Google Analytics account.'
+- title: Dimensions and Metrics Explorer
+  type: tool
+  slug: dimensions-metrics-explorer
+  tech:
+
 - title: Enhanced Ecommerce
   type: demo
   slug: enhanced-ecommerce
-  tech: [analyticsjs, ecjs]
+  tech:
+  - analyticsjs
+  - ecjs
   external:
     action: View Demo
     url: https://enhancedecommerce.appspot.com
 - title: Hit Builder
   type: tool
   slug: hit-builder
-  tech: [measurement_protocol_validation_server]
+  tech:
+  - measurement_protocol_validation_server
 - title: Polymer Elements
   type: demo
   slug: polymer-elements
-  tech: [management_api, metadata_api]
+  tech:
+  - management_api
+  - metadata_api
   external:
     action: View Demo
     url: https://elements.polymer-project.org/elements/google-analytics?view=demo:demo/index.html
@@ -91,7 +114,9 @@ projects:
 - title: Tag Assistant
   type: demo
   slug: tag-assistant
-  tech: [tag_assistant, analyticsjs]
+  tech:
+  - tag_assistant
+  - analyticsjs
   external:
     action: Get Extension
     url: https://chrome.google.com/webstore/detail/tag-assistant-by-google/kejbdjndbnbjgmefkgdddjlbokphdefk
@@ -99,7 +124,10 @@ projects:
   type: tool
   slug: usage-trends
   status: new
-  tech: [analytics_reporting_api_v4, management_api, metadata_api]
+  tech:
+  - analytics_reporting_api_v4
+  - management_api
+  - metadata_api
 
 
 # Google Analytics tech tags. Demos and tools should tag themselves with


### PR DESCRIPTION
Simple edit to `meta.yaml` that replaces `[]` lists with indented bulleted lists. Should be completely invisible; these are identical to the yaml structure