### PR TITLE
Add production configuration options

### DIFF
--- a/to-gatsby/lib/scripts/build.ts
+++ b/to-gatsby/lib/scripts/build.ts
@@ -1,5 +1,4 @@
 import { checkConfig } from "./check-config"
-import { RuntimeJson } from "./types"
 import * as execa from "execa"
 
 const checkTypes = async () => {

--- a/to-gatsby/lib/scripts/check-config.ts
+++ b/to-gatsby/lib/scripts/check-config.ts
@@ -6,6 +6,9 @@ import {
   Encoding,
   DotEnvDevelopmentPath,
   DotEnvProductionPath,
+  ConfigAnswers,
+  ProductionConfig,
+  DevelopmentConfig,
 } from "./types"
 import * as execa from "execa"
 
@@ -16,6 +19,9 @@ type ConfigQuestionFilter = {
 const ensureNecessaryFiles = async (
   runtimeJson: RuntimeJson
 ): Promise<RuntimeJson> => {
+  // TODO - Ideally this only re-writes a file if there's actually a difference
+  // between the current one and the new data.
+
   // Create `runtime.json` if it doesn't exist.
   const exists = fs.existsSync(RuntimeJsonPath)
   if (!exists) {
@@ -42,8 +48,8 @@ const ensureNecessaryFiles = async (
   fs.writeFileSync(
     DotEnvDevelopmentPath,
     [
-      `GAPI_CLIENT_ID=${runtimeJson.gapiClientId}`,
-      `GA_MEASUREMENT_ID=${runtimeJson.gaMeasurementIdDev}`,
+      `GAPI_CLIENT_ID=${runtimeJson.development.gapiClientId}`,
+      `GA_MEASUREMENT_ID=${runtimeJson.development.gaMeasurementId}`,
     ].join("\n"),
     { encoding: Encoding }
   )
@@ -51,13 +57,11 @@ const ensureNecessaryFiles = async (
   fs.writeFileSync(
     DotEnvProductionPath,
     [
-      `GAPI_CLIENT_ID=${runtimeJson.gapiClientId}`,
-      `GA_MEASUREMENT_ID=${runtimeJson.gaMeasurementId}`,
+      `GAPI_CLIENT_ID=${runtimeJson.production.gapiClientId}`,
+      `GA_MEASUREMENT_ID=${runtimeJson.production.gaMeasurementId}`,
     ].join("\n"),
     { encoding: Encoding }
   )
-
-  console.log("Writing `runtime.json`.")
 
   return runtimeJson
 }
@@ -67,17 +71,21 @@ const ensureNecessaryFiles = async (
 // be skipped if already provided.
 const configQuestions = (
   filter: ConfigQuestionFilter
-): inquirer.QuestionCollection<RuntimeJson> => {
+): inquirer.QuestionCollection<ConfigAnswers> => {
+  // TODO the `?.`s can be removed once this has stabilized. They're here now to
+  // be friendly as the runtimeJson type evolves.
   return [
     {
-      name: "gaMeasurementId",
+      name: "gaMeasurementIdProd",
       // TODO - Nice to have, list the user's available properties. Would
       // require the user to authenticate first to make the request.
       type: "input",
       message: "Google Analytics measurement ID for production: ",
-      default: filter.gaMeasurementId || "none-provided",
+      default: filter?.production?.gaMeasurementId || "none-provided",
       when: () => {
-        return filter.askAll || filter.gaMeasurementId === undefined
+        return (
+          filter.askAll || filter?.production?.gaMeasurementId === undefined
+        )
       },
     },
     {
@@ -86,30 +94,57 @@ const configQuestions = (
       // require the user to authenticate first to make the request.
       type: "input",
       message: "Google Analytics measurement ID for development: ",
-      default: filter.gaMeasurementIdDev || "none-provided",
+      default: filter?.development?.gaMeasurementId || "none-provided",
       when: () => {
-        return filter.askAll || filter.gaMeasurementIdDev === undefined
+        return (
+          filter.askAll || filter?.development?.gaMeasurementId === undefined
+        )
       },
     },
     {
-      name: "firebaseStagingProjectId",
+      name: "firebaseProjectIdProd",
       type: "input",
-      message: "Firebase project ID to use for staging environment:",
+      message: "Firebase project ID to use for production:",
       // TODO - See if listing is useful. Probably should only do it if there's not a ton.
-      default: filter.firebaseStagingProjectId,
+      default: filter?.production?.firebaseProjectId,
       when: () => {
-        return filter.askAll || filter.firebaseStagingProjectId === undefined
+        return (
+          filter.askAll || filter?.production?.firebaseProjectId === undefined
+        )
       },
     },
     {
-      name: "gapiClientId",
+      name: "firebaseProjectIdDev",
+      type: "input",
+      message: "Firebase project ID to use for development environment:",
+      // TODO - See if listing is useful. Probably should only do it if there's not a ton.
+      default: filter?.development?.firebaseProjectId,
+      when: () => {
+        return (
+          filter.askAll || filter?.development?.firebaseProjectId === undefined
+        )
+      },
+    },
+    {
+      name: "gapiClientIdProd",
       type: "input",
       // TODO - Check to see if there a way to make getting this value easier.
       // (or at least provide a link to where the user can find this value)
-      message: "Client ID to use for user authentication to this site.",
-      default: filter.gapiClientId,
+      message: "Google client ID to use for production:",
+      default: filter?.production?.gapiClientId,
       when: () => {
-        return filter.askAll || filter.gapiClientId === undefined
+        return filter.askAll || filter?.production?.gapiClientId === undefined
+      },
+    },
+    {
+      name: "gapiClientIdDev",
+      type: "input",
+      // TODO - Check to see if there a way to make getting this value easier.
+      // (or at least provide a link to where the user can find this value)
+      message: "Google client ID to use for development environment:",
+      default: filter?.development?.gapiClientId,
+      when: () => {
+        return filter.askAll || filter?.development?.gapiClientId === undefined
       },
     },
   ]
@@ -137,7 +172,7 @@ export const checkConfig = async (): Promise<RuntimeJson> => {
   const exists = fs.existsSync(RuntimeJsonPath)
 
   let filter: ConfigQuestionFilter = {}
-  let currentConfig: Partial<RuntimeJson> = {}
+  let currentConfig: RuntimeJson | undefined
 
   // If the file doesn't exist at all, prompt for all configuration entries.
   if (!exists) {
@@ -156,12 +191,69 @@ export const checkConfig = async (): Promise<RuntimeJson> => {
   // Make sure user is logged into Firebase.
   await ensureFirebaseLoginStatus()
 
-  const answers = await inquirer.prompt(
-    configQuestions(Object.assign({}, currentConfig, filter))
-  )
+  const questions = configQuestions(Object.assign({}, currentConfig, filter))
 
-  const merged = Object.assign({}, currentConfig, answers)
+  const answers: Partial<ConfigAnswers> = await inquirer.prompt(questions)
 
-  const config = await ensureNecessaryFiles(merged)
+  const asRuntime = toRuntimeJson(answers, currentConfig)
+
+  const config = await ensureNecessaryFiles(asRuntime)
   return config
+}
+
+const toRuntimeJson = (
+  answers: Partial<ConfigAnswers>,
+  currentConfig: RuntimeJson
+): RuntimeJson => {
+  const production: ProductionConfig = {
+    gaMeasurementId:
+      answers.gaMeasurementIdProd || currentConfig.production.gaMeasurementId,
+    firebaseProjectId:
+      answers.firebaseProjectIdProd ||
+      currentConfig.production.firebaseProjectId,
+    gapiClientId:
+      answers.gapiClientIdProd || currentConfig.production.gapiClientId,
+  }
+
+  const development: DevelopmentConfig = {
+    gaMeasurementId:
+      answers.gaMeasurementIdDev || currentConfig.development.gaMeasurementId,
+    firebaseProjectId:
+      answers.firebaseProjectIdDev ||
+      currentConfig.development.firebaseProjectId,
+    gapiClientId:
+      answers.gapiClientIdDev || currentConfig.development.gapiClientId,
+  }
+
+  const fullConfig = { production, development }
+
+  return assertAllValues(fullConfig)
+}
+
+const assertAllValues = (runtimeJson: RuntimeJson): RuntimeJson => {
+  if (runtimeJson.development.gapiClientId === undefined) {
+    throw new Error("Missing the development gapiClientId")
+  }
+
+  if (runtimeJson.development.gaMeasurementId === undefined) {
+    throw new Error("Missing the development gaMeasurementId")
+  }
+
+  if (runtimeJson.development.firebaseProjectId === undefined) {
+    throw new Error("Missing the development firebaseProjectId")
+  }
+
+  if (runtimeJson.production.gapiClientId === undefined) {
+    throw new Error("Missing the production gapiClientId")
+  }
+
+  if (runtimeJson.production.gaMeasurementId === undefined) {
+    throw new Error("Missing the production gaMeasurementId")
+  }
+
+  if (runtimeJson.production.firebaseProjectId === undefined) {
+    throw new Error("Missing the production firebaseProjectId")
+  }
+
+  return runtimeJson
 }

--- a/to-gatsby/lib/scripts/check-config.ts
+++ b/to-gatsby/lib/scripts/check-config.ts
@@ -102,6 +102,10 @@ const configQuestions = (
       },
     },
     {
+      // TODO - Nice to have. Accept a value that lets the user create a new
+      // firebase project if they don't already have one. The firebase cli
+      // supports this so it shouldn't bee too tricky. This should probably use
+      // the --json flag for the cli so the data comes back in a useful format.
       name: "firebaseProjectIdProd",
       type: "input",
       message: "Firebase project ID to use for production:",

--- a/to-gatsby/lib/scripts/index.ts
+++ b/to-gatsby/lib/scripts/index.ts
@@ -33,7 +33,7 @@ const getParser = async (): Promise<argparse.ArgumentParser> => {
   // TODO - It's probably worth implementing a workaround so this can be built
   // using the development environment variables. Right now, this works great
   // for local development, but it's less useful for the staging site.
-  subparsers.addParser(Command.Deploy, {
+  const deployParser = subparsers.addParser(Command.Deploy, {
     help:
       "Builds the project and deploys it to `--environment`. Note that due to a limitation in `gatsby build`, this will always use the production environment variables. Only the firebase projectId will be changed",
   })
@@ -54,7 +54,7 @@ const getParser = async (): Promise<argparse.ArgumentParser> => {
   })
 
   // Add the environment argument to all commands that support it.
-  ;[buildParser, serveParser].forEach(parser => {
+  ;[buildParser, serveParser, deployParser].forEach(parser => {
     parser.addArgument("--environment", {
       required: true,
       dest: "environment",

--- a/to-gatsby/lib/scripts/serve.ts
+++ b/to-gatsby/lib/scripts/serve.ts
@@ -1,12 +1,17 @@
 import * as execa from "execa"
 import { build } from "./build"
-import { ServeArgs } from "./types"
+import { ServeArgs, Environment } from "./types"
 import { checkConfig } from "./check-config"
 
 export const serve = async (args: ServeArgs) => {
-  // TODO - in the future this should get the right id based on which
-  // environment you're building/serving.
-  const { firebaseStagingProjectId: projectId } = await checkConfig()
+  const config = await checkConfig()
+
+  let projectId: string
+  if (args.environment === Environment.Development) {
+    projectId = config.development.firebaseProjectId
+  } else if (args.environment === Environment.Production) {
+    projectId = config.production.firebaseProjectId
+  }
 
   if (!args.skipBuild) {
     await build(false)

--- a/to-gatsby/lib/scripts/serve.ts
+++ b/to-gatsby/lib/scripts/serve.ts
@@ -9,6 +9,9 @@ export const serve = async (args: ServeArgs) => {
   let projectId: string
   if (args.environment === Environment.Development) {
     projectId = config.development.firebaseProjectId
+    console.warn(
+      `Note: serving using the development environment isn't fully supported. You should use "yarn start" instead to run locally.`
+    )
   } else if (args.environment === Environment.Production) {
     projectId = config.production.firebaseProjectId
   }

--- a/to-gatsby/lib/scripts/stage.ts
+++ b/to-gatsby/lib/scripts/stage.ts
@@ -9,6 +9,9 @@ export const stage = async (args: DeployArgs) => {
   let projectId: string
   if (args.environment === Environment.Development) {
     projectId = config.development.firebaseProjectId
+    console.warn(
+      `Note: deploying using the development environment isn't fully supported. Deployment will use the production configuration values. Only the firebase project ID will be used.`
+    )
   } else if (args.environment === Environment.Production) {
     projectId = config.production.firebaseProjectId
   }

--- a/to-gatsby/lib/scripts/stage.ts
+++ b/to-gatsby/lib/scripts/stage.ts
@@ -1,15 +1,16 @@
 import * as execa from "execa"
 import { build } from "./build"
 import { checkConfig } from "./check-config"
+import { DeployArgs, Environment } from "./types"
 
-export const stage = async (environment: "integration" | "production") => {
+export const stage = async (args: DeployArgs) => {
   const config = await checkConfig()
 
-  const projectId =
-    environment === "integration" ? config.firebaseStagingProjectId : undefined
-
-  if (projectId === undefined) {
-    throw new Error("Production deployments are not yet supported.")
+  let projectId: string
+  if (args.environment === Environment.Development) {
+    projectId = config.development.firebaseProjectId
+  } else if (args.environment === Environment.Production) {
+    projectId = config.production.firebaseProjectId
   }
 
   await build(false)

--- a/to-gatsby/lib/scripts/types.ts
+++ b/to-gatsby/lib/scripts/types.ts
@@ -6,12 +6,32 @@ export const RuntimeJsonPath = path.join(PWD, "runtime.json")
 export const DotEnvDevelopmentPath = path.join(PWD, ".env.development")
 export const DotEnvProductionPath = path.join(PWD, ".env.production")
 
-export interface RuntimeJson {
+interface CommonConfig {
   gaMeasurementId: string
-  gaMeasurementIdDev: string
-  firebaseStagingProjectId: string
-  // TODO there should be a different gapiClientID for production and development.
+  firebaseProjectId: string
   gapiClientId: string
+}
+
+export interface ProductionConfig extends CommonConfig {}
+export interface DevelopmentConfig extends CommonConfig {}
+
+export interface ConfigAnswers {
+  gaMeasurementIdProd: string
+  gaMeasurementIdDev: string
+  firebaseProjectIdProd: string
+  firebaseProjectIdDev: string
+  gapiClientIdProd: string
+  gapiClientIdDev: string
+}
+
+export interface RuntimeJson {
+  production: ProductionConfig
+  development: DevelopmentConfig
+}
+
+export enum Environment {
+  Production = "production",
+  Development = "development",
 }
 
 interface CheckRuntimeFilesArgs {
@@ -29,10 +49,12 @@ interface DevelopArgs {
 export interface ServeArgs {
   cmd: Command.Serve
   skipBuild: boolean
+  environment: Environment
 }
 
-interface StageToIntegrationArgs {
-  cmd: Command.StageToIntegration
+export interface DeployArgs {
+  cmd: Command.Deploy
+  environment: Environment
 }
 
 export enum Command {
@@ -40,7 +62,7 @@ export enum Command {
   Build = "build",
   Develop = "develop",
   Serve = "serve",
-  StageToIntegration = "stage:integration",
+  Deploy = "deploy",
 }
 
 export type Args =
@@ -48,4 +70,4 @@ export type Args =
   | ServeArgs
   | BuildArgs
   | DevelopArgs
-  | StageToIntegrationArgs
+  | DeployArgs

--- a/to-gatsby/package.json
+++ b/to-gatsby/package.json
@@ -77,7 +77,7 @@
     "generate-scripts": "cd lib && yarn build",
     "serve:development": "yarn generate-scripts && node lib/build/index.js serve --environment=development",
     "check-config": "yarn generate-scripts && node lib/build/index.js check-config",
-    "build": "yarn generate-scripts && node lib/build/index.js build",
+    "build:production": "yarn generate-scripts && node lib/build/index.js build --environment=production",
     "develop": "yarn generate-scripts && node lib/build/index.js develop",
     "deploy:development": "yarn generate-scripts && node lib/build/index.js deploy --environment=development",
     "deploy:production": "yarn generate-scripts && node lib/build/index.js deploy --environment=production"

--- a/to-gatsby/package.json
+++ b/to-gatsby/package.json
@@ -75,11 +75,10 @@
     "clean": "gatsby clean",
 
     "generate-scripts": "cd lib && yarn build",
-    "serve:development": "yarn generate-scripts && node lib/build/index.js serve --environment=development",
+    "serve:production": "yarn generate-scripts && node lib/build/index.js serve --environment=production",
     "check-config": "yarn generate-scripts && node lib/build/index.js check-config",
     "build:production": "yarn generate-scripts && node lib/build/index.js build --environment=production",
     "develop": "yarn generate-scripts && node lib/build/index.js develop",
-    "deploy:development": "yarn generate-scripts && node lib/build/index.js deploy --environment=development",
     "deploy:production": "yarn generate-scripts && node lib/build/index.js deploy --environment=production"
   }
 }

--- a/to-gatsby/package.json
+++ b/to-gatsby/package.json
@@ -68,16 +68,18 @@
     "typescript": "^3.8.3"
   },
   "scripts": {
+    "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
+    "check-types": "tsc",
+    "test": "yarn check-types && jest",
+    "start": "yarn run develop",
+    "clean": "gatsby clean",
+
     "generate-scripts": "cd lib && yarn build",
+    "serve:development": "yarn generate-scripts && node lib/build/index.js serve --environment=development",
     "check-config": "yarn generate-scripts && node lib/build/index.js check-config",
     "build": "yarn generate-scripts && node lib/build/index.js build",
     "develop": "yarn generate-scripts && node lib/build/index.js develop",
-    "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
-    "start": "yarn run develop",
-    "serve": "yarn generate-scripts && node lib/build/index.js serve",
-    "stage:integration": "yarn generate-scripts && node lib/build/index.js stage:integration",
-    "clean": "gatsby clean",
-    "check-types": "tsc",
-    "test": "yarn check-types && jest"
+    "deploy:development": "yarn generate-scripts && node lib/build/index.js deploy --environment=development",
+    "deploy:production": "yarn generate-scripts && node lib/build/index.js deploy --environment=production"
   }
 }


### PR DESCRIPTION
Adds in the rest of the required functionality for a MVP set of scripts that supports a production & staging environment. 

Updates the runtime.json file format to have top-level keys `production` and `development` that make it very clear which values are being used for which environment. 

Can try this out by running the various updated scripts:

+ `yarn check-config`
+ `yarn generate-scripts`
+ `yarn serve:production`
+ etc...