### PR TITLE
View selector now allows selection of accounts & properties with no views

### DIFF
--- a/src/components/AccountExplorer/ViewTable.tsx
+++ b/src/components/AccountExplorer/ViewTable.tsx
@@ -13,6 +13,7 @@ import HighlightText from "./HighlightText"
 import Spinner from "@/components/Spinner"
 import { RequestStatus } from "@/types"
 import useFlattenedViews from "../ViewSelector/useFlattenedViews"
+import { AccountSummary, ProfileSummary, WebPropertySummary } from "@/types/ua"
 
 const useStyles = makeStyles(theme => ({
   id: {
@@ -46,7 +47,7 @@ interface ViewCellProps {
   copyToolTip: string
   textToCopy: string
 }
-const ViewCell: React.FC<ViewCellProps> = ({
+const APVCell: React.FC<ViewCellProps> = ({
   firstRow,
   secondRow,
   copyToolTip,
@@ -80,6 +81,121 @@ const textClamp = (text: string, maxWidth: number) => {
   }
 }
 
+const AccountCell: React.FC<{
+  account: AccountSummary | undefined
+  classes: ReturnType<typeof useStyles>
+  search: string | undefined
+}> = ({ account, classes, search }) => {
+  if (account === undefined) {
+    return null
+  }
+  return (
+    <APVCell
+      textToCopy={account?.id || ""}
+      copyToolTip="Copy account ID"
+      firstRow={
+        <HighlightText
+          className={classes.mark}
+          search={search}
+          text={textClamp(account?.name || "", maxCellWidth)}
+        />
+      }
+      secondRow={
+        <HighlightText
+          className={classes.mark}
+          search={search}
+          text={account?.id || ""}
+        />
+      }
+    />
+  )
+}
+
+const PropertyCell: React.FC<{
+  property: WebPropertySummary | undefined
+  classes: ReturnType<typeof useStyles>
+  search: string | undefined
+}> = ({ property, classes, search }) => {
+  if (property === undefined) {
+    return <TableCell>No UA properties for account.</TableCell>
+  }
+
+  return (
+    <APVCell
+      textToCopy={property?.id || ""}
+      copyToolTip="Copy property ID"
+      firstRow={
+        <HighlightText
+          className={classes.mark}
+          search={search}
+          text={textClamp(property!.name!, maxCellWidth)}
+        />
+      }
+      secondRow={
+        <HighlightText
+          className={classes.mark}
+          search={search}
+          text={property!.id!}
+        />
+      }
+    />
+  )
+}
+
+const ViewCell: React.FC<{
+  account: AccountSummary | undefined
+  property: WebPropertySummary | undefined
+  view: ProfileSummary | undefined
+  classes: ReturnType<typeof useStyles>
+  search: string | undefined
+}> = ({ account, property, view, classes, search }) => {
+  if (view === undefined) {
+    return <TableCell colSpan={2}>No UA views for account.</TableCell>
+  }
+  const viewUrl = `https://analytics.google.com/analytics/web/#/report/vistors-overview/a${account?.id}w${property?.internalWebPropertyId}p${view?.id}`
+  return (
+    <React.Fragment>
+      <APVCell
+        textToCopy={view!.id!}
+        copyToolTip="Copy view ID"
+        firstRow={
+          <a
+            className={classes.link}
+            href={viewUrl}
+            title="Open this view in Google Analytics"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <HighlightText
+              className={classes.mark}
+              search={search}
+              text={textClamp(view!.name!, maxCellWidth)}
+            />
+          </a>
+        }
+        secondRow={
+          <HighlightText
+            className={classes.mark}
+            search={search}
+            text={view!.id!}
+          />
+        }
+      />
+      <APVCell
+        textToCopy={`ga:${view!.id!}`}
+        copyToolTip="Copy table ID"
+        firstRow={
+          <HighlightText
+            className={classes.mark}
+            search={search}
+            text={`ga:${view!.id!}`}
+          />
+        }
+      />
+    </React.Fragment>
+  )
+}
+
 const ViewsTable: React.FC<ViewTableProps> = ({
   flattenedViewsRequest,
   className,
@@ -108,87 +224,26 @@ const ViewsTable: React.FC<ViewTableProps> = ({
             </TableRow>
           ) : (
             flattenedViewsRequest.flattenedViews.map(apv => {
-              const viewUrl = `https://analytics.google.com/analytics/web/#/report/vistors-overview/a${
-                apv!.account!.id
-              }w${apv!.property!.internalWebPropertyId}p${apv!.view!.id}`
               return (
                 <TableRow
-                  key={`${apv!.account!.name}-${apv!.property!.name}-${
-                    apv!.view!.name
-                  }`}
+                  key={`${apv?.account?.name}-${apv?.property?.name}-${apv?.view?.name}`}
                 >
-                  <ViewCell
-                    textToCopy={apv!.account!.id!}
-                    copyToolTip="Copy account ID"
-                    firstRow={
-                      <HighlightText
-                        className={classes.mark}
-                        search={search}
-                        text={textClamp(apv!.account!.name!, maxCellWidth)}
-                      />
-                    }
-                    secondRow={
-                      <HighlightText
-                        className={classes.mark}
-                        search={search}
-                        text={apv!.account!.id!}
-                      />
-                    }
+                  <AccountCell
+                    account={apv.account}
+                    classes={classes}
+                    search={search}
+                  />
+                  <PropertyCell
+                    property={apv.property}
+                    classes={classes}
+                    search={search}
                   />
                   <ViewCell
-                    textToCopy={apv!.property!.id!}
-                    copyToolTip="Copy property ID"
-                    firstRow={
-                      <HighlightText
-                        className={classes.mark}
-                        search={search}
-                        text={textClamp(apv!.property!.name!, maxCellWidth)}
-                      />
-                    }
-                    secondRow={
-                      <HighlightText
-                        className={classes.mark}
-                        search={search}
-                        text={apv!.property!.id!}
-                      />
-                    }
-                  />
-                  <ViewCell
-                    textToCopy={apv!.view!.id!}
-                    copyToolTip="Copy view ID"
-                    firstRow={
-                      <a
-                        className={classes.link}
-                        href={viewUrl}
-                        title="Open this view in Google Analytics"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <HighlightText
-                          className={classes.mark}
-                          search={search}
-                          text={textClamp(apv!.view!.name!, maxCellWidth)}
-                        />
-                      </a>
-                    }
-                    secondRow={
-                      <HighlightText
-                        className={classes.mark}
-                        search={search}
-                        text={apv!.view!.id!}
-                      />
-                    }
-                  />
-                  <ViewCell
-                    textToCopy={`ga:${apv!.view!.id!}`}
-                    copyToolTip="Copy table ID"
-                    firstRow={
-                      <HighlightText
-                        className={classes.mark}
-                        search={search}
-                        text={`ga:${apv!.view!.id!}`}
-                      />
-                    }
+                    account={apv.account}
+                    property={apv.property}
+                    view={apv.view}
+                    classes={classes}
+                    search={search}
                   />
                 </TableRow>
               )

--- a/src/components/ViewSelector/index.spec.tsx
+++ b/src/components/ViewSelector/index.spec.tsx
@@ -1,0 +1,121 @@
+// Copyright 2020 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from "react"
+
+import * as renderer from "@testing-library/react"
+import { withProviders } from "@/test-utils"
+import "@testing-library/jest-dom"
+import Sut, { Label, TestID } from "./index"
+import useAccountPropertyView from "./useAccountPropertyView"
+import { StorageKey } from "@/constants"
+import { fireEvent, within } from "@testing-library/react"
+import { AccountSummary } from "@/types/ua"
+
+enum QueryParam {
+  Account = "a",
+  Property = "b",
+  View = "c",
+}
+
+describe("ViewSelector", () => {
+  const DefaultSut: React.FC = () => {
+    const apv = useAccountPropertyView("a" as StorageKey, QueryParam)
+    return <Sut {...apv} />
+  }
+  test("doesn't crash on happy path", async () => {
+    const { wrapped } = withProviders(<DefaultSut />)
+    const { findByLabelText } = renderer.render(wrapped)
+
+    const account = await findByLabelText(Label.Account)
+    expect(account).toBeVisible()
+
+    const property = await findByLabelText(Label.Property)
+    expect(property).toBeVisible()
+
+    const view = await findByLabelText(Label.View)
+    expect(view).toBeVisible()
+  })
+  test("can select account with no properties", async () => {
+    const accountName = "my account name"
+    const listAccountSummaries = jest.fn<Promise<AccountSummary[]>, any>()
+    listAccountSummaries.mockReturnValue(
+      Promise.resolve([{ name: accountName, id: "account id", properties: [] }])
+    )
+    const { wrapped } = withProviders(<DefaultSut />, {
+      uaListAccountSummaries: listAccountSummaries,
+    })
+    const { findByTestId } = renderer.render(wrapped)
+
+    // Select first account.
+    const accountAC = await findByTestId(TestID.AccountAutocomplete)
+    fireEvent.keyDown(accountAC, { key: "ArrowDown" })
+    fireEvent.keyDown(accountAC, { key: "Enter" })
+
+    const accountInput = within(accountAC).getByRole("textbox")
+    expect(accountInput).toHaveValue(accountName)
+  })
+  describe("with autoFill={true}", () => {
+    const WithAutoFill: React.FC = () => {
+      const apv = useAccountPropertyView("a" as StorageKey, QueryParam)
+      return <Sut {...apv} autoFill />
+    }
+    test("automatically selects account & view when both available", async () => {
+      const { wrapped } = withProviders(<WithAutoFill />)
+      const { findByTestId } = renderer.render(wrapped)
+
+      // Select first account.
+      const accountAC = await findByTestId(TestID.AccountAutocomplete)
+      fireEvent.keyDown(accountAC, { key: "ArrowDown" })
+      fireEvent.keyDown(accountAC, { key: "Enter" })
+
+      const accountInput = within(accountAC).getByRole("textbox")
+      expect(accountInput).toHaveValue("Account Name 1")
+
+      const propertyAC = await findByTestId(TestID.PropertyAutocomplete)
+      const propertyInput = within(propertyAC).getByRole("textbox")
+      expect(propertyInput).toHaveValue("Property Name 1 1")
+
+      const viewAC = await findByTestId(TestID.ViewAutocomplete)
+      const viewInput = within(viewAC).getByRole("textbox")
+      expect(viewInput).toHaveValue("View Name 1 1 1")
+    })
+  })
+  describe("with autoFill={false}", () => {
+    const NoAutoFill: React.FC = () => {
+      const apv = useAccountPropertyView("a" as StorageKey, QueryParam)
+      return <Sut {...apv} autoFill={false} />
+    }
+    test("doesn't automatically select property or view after selecting property", async () => {
+      const { wrapped } = withProviders(<NoAutoFill />)
+      const { findByTestId } = renderer.render(wrapped)
+
+      // Select first account.
+      const accountAC = await findByTestId(TestID.AccountAutocomplete)
+      fireEvent.keyDown(accountAC, { key: "ArrowDown" })
+      fireEvent.keyDown(accountAC, { key: "Enter" })
+
+      const accountInput = within(accountAC).getByRole("textbox")
+      expect(accountInput).toHaveValue("Account Name 1")
+
+      const propertyAC = await findByTestId(TestID.PropertyAutocomplete)
+      const propertyInput = within(propertyAC).getByRole("textbox")
+      expect(propertyInput).toHaveValue("")
+
+      const viewAC = await findByTestId(TestID.ViewAutocomplete)
+      const viewInput = within(viewAC).getByRole("textbox")
+      expect(viewInput).toHaveValue("")
+    })
+  })
+})

--- a/src/components/ViewSelector/index.tsx
+++ b/src/components/ViewSelector/index.tsx
@@ -50,6 +50,18 @@ interface AlsoView extends CommonProps {
 
 type ViewSelectorProps = AlsoView | OnlyProperty
 
+export enum Label {
+  Account = "account",
+  Property = "property",
+  View = "view",
+}
+
+export enum TestID {
+  AccountAutocomplete = "account-autocomplete",
+  PropertyAutocomplete = "property-autocomplete",
+  ViewAutocomplete = "view-autocomplete",
+}
+
 const ViewSelector: React.FC<ViewSelectorProps> = props => {
   const {
     autoFill,
@@ -68,6 +80,7 @@ const ViewSelector: React.FC<ViewSelectorProps> = props => {
   return (
     <div className={classnames(classes.root, className)}>
       <Autocomplete<AccountSummary>
+        data-testid={TestID.AccountAutocomplete}
         blurOnSelect
         openOnFocus
         autoHighlight
@@ -94,13 +107,14 @@ const ViewSelector: React.FC<ViewSelectorProps> = props => {
         renderInput={params => (
           <TextField
             {...params}
-            label="account"
+            label={Label.Account}
             size={size}
             variant={variant}
           />
         )}
       />
       <Autocomplete<WebPropertySummary>
+        data-testid={TestID.PropertyAutocomplete}
         blurOnSelect
         openOnFocus
         autoHighlight
@@ -127,7 +141,7 @@ const ViewSelector: React.FC<ViewSelectorProps> = props => {
         renderInput={params => (
           <TextField
             {...params}
-            label="property"
+            label={Label.Property}
             size={size}
             variant={variant}
           />
@@ -135,6 +149,7 @@ const ViewSelector: React.FC<ViewSelectorProps> = props => {
       />
       {props.onlyProperty ? null : (
         <Autocomplete<ProfileSummary>
+          data-testid={TestID.ViewAutocomplete}
           blurOnSelect
           openOnFocus
           autoHighlight
@@ -155,7 +170,12 @@ const ViewSelector: React.FC<ViewSelectorProps> = props => {
           }}
           getOptionLabel={view => view.name || ""}
           renderInput={params => (
-            <TextField {...params} label="view" size={size} variant={variant} />
+            <TextField
+              {...params}
+              label={Label.View}
+              size={size}
+              variant={variant}
+            />
           )}
         />
       )}

--- a/src/components/ViewSelector/useFlattenedViews.ts
+++ b/src/components/ViewSelector/useFlattenedViews.ts
@@ -44,10 +44,16 @@ const useFlattenedViews = (
             const account = { ...summary }
 
             const properties = summary.webProperties || []
+            if (properties.length === 0) {
+              return { account }
+            }
             return properties.flatMap(propertySummary => {
               const property = { ...propertySummary }
 
               const profiles = propertySummary.profiles || []
+              if (profiles.length === 0) {
+                return { account, property }
+              }
               return profiles.map(profile => ({
                 view: profile,
                 property,

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -27,6 +27,7 @@ import { AccountSummary, Column } from "./types/ua"
 interface WithProvidersConfig {
   path?: string
   isLoggedIn?: boolean
+  uaListAccountSummaries?: () => Promise<gapi.client.analytics.AccountSummary[]>
 }
 
 export const wrapperFor: (options: {
@@ -64,7 +65,10 @@ export const TestWrapper = wrapperFor({})
 
 export const withProviders = (
   component: JSX.Element | null,
-  { path, isLoggedIn }: WithProvidersConfig = { path: "/", isLoggedIn: true }
+  { path, isLoggedIn, uaListAccountSummaries }: WithProvidersConfig = {
+    path: "/",
+    isLoggedIn: true,
+  }
 ): {
   wrapped: JSX.Element
   history: History
@@ -85,7 +89,7 @@ export const withProviders = (
     store.dispatch({ type: "setUser", user: undefined })
   }
 
-  const gapi = testGapi()
+  const gapi = testGapi({ uaListAccountSummaries })
   store.dispatch({ type: "setGapi", gapi })
 
   const wrapped = (
@@ -424,7 +428,7 @@ const metadataColumnsPromise = Promise.resolve({
   },
 })
 
-export const testGapi = () => ({
+export const testGapi = ({ uaListAccountSummaries }: WithProvidersConfig) => ({
   client: {
     analyticsadmin: {
       properties: {
@@ -501,7 +505,16 @@ export const testGapi = () => ({
       },
     },
     analytics: {
-      management: { accountSummaries: { list: () => listPromise } },
+      management: {
+        accountSummaries: {
+          list: uaListAccountSummaries
+            ? () =>
+                uaListAccountSummaries().then(a => ({
+                  result: { items: a },
+                }))
+            : () => listPromise,
+        },
+      },
       metadata: {
         columns: {
           list: () => {

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -428,7 +428,9 @@ const metadataColumnsPromise = Promise.resolve({
   },
 })
 
-export const testGapi = ({ uaListAccountSummaries }: WithProvidersConfig) => ({
+export const testGapi = ({
+  uaListAccountSummaries,
+}: WithProvidersConfig | undefined = {}) => ({
   client: {
     analyticsadmin: {
       properties: {


### PR DESCRIPTION
This is useful for the Account Explorer in particular since there are many users
with GA4 only accounts and we can now surface that a given account has no UA
properties or views.

+ [staged](https://ga-dev-tools-integration.web.app/account-explorer/)