### PR TITLE
Improve Filtering Logic for dropdowns

### DIFF
--- a/src/components/GA4Pickers/index.tsx
+++ b/src/components/GA4Pickers/index.tsx
@@ -15,7 +15,9 @@
 import * as React from "react"
 
 import { Typography, TextField, makeStyles } from "@material-ui/core"
-import Autocomplete from "@material-ui/lab/Autocomplete"
+import Autocomplete, {
+  createFilterOptions,
+} from "@material-ui/lab/Autocomplete"
 import { useState } from "react"
 import { Dispatch, RequestStatus } from "@/types"
 import useAvailableColumns from "./useAvailableColumns"
@@ -56,6 +58,9 @@ const Column: React.FC<{ column: GA4Column }> = ({ column }) => {
   )
 }
 
+const dimensionsFilterOptions = createFilterOptions<GA4Dimension>({
+  stringify: option => `${option.uiName} ${option.apiName}`,
+})
 export const DimensionsPicker: React.FC<{
   dimensions: GA4Dimensions
   // TODO - migrate away entirely from setDimensions and only use the IDs and make
@@ -82,6 +87,7 @@ export const DimensionsPicker: React.FC<{
 
   return (
     <Autocomplete<NonNullable<GA4Dimension>, true, undefined, true>
+      filterOptions={dimensionsFilterOptions}
       fullWidth
       autoComplete
       autoHighlight
@@ -118,6 +124,9 @@ export const DimensionsPicker: React.FC<{
   )
 }
 
+const metricsFilterOptions = createFilterOptions<GA4Metric>({
+  stringify: option => `${option.uiName} ${option.apiName}`,
+})
 export const MetricsPicker: React.FC<{
   metrics: GA4Metrics
   // TODO - migrate away entirely from setMetrics and only use the IDs and make
@@ -146,6 +155,7 @@ export const MetricsPicker: React.FC<{
 
   return (
     <Autocomplete<GA4Metric, true, undefined, true>
+      filterOptions={metricsFilterOptions}
       fullWidth
       autoComplete
       autoHighlight
@@ -244,6 +254,7 @@ export const DimensionPicker: React.FC<{
 
   return (
     <Autocomplete<NonNullable<GA4Dimension>, false, undefined, true>
+      filterOptions={dimensionsFilterOptions}
       className={className}
       fullWidth
       autoComplete
@@ -330,6 +341,7 @@ export const MetricPicker: React.FC<{
 
   return (
     <Autocomplete<NonNullable<GA4Metric>, false, undefined, true>
+      filterOptions={metricsFilterOptions}
       className={className}
       fullWidth
       autoComplete

--- a/src/components/UAPickers/index.tsx
+++ b/src/components/UAPickers/index.tsx
@@ -75,6 +75,10 @@ const Column: React.FC<{ column: ColumnT }> = ({ column }) => {
   )
 }
 
+const columnFilterOptions = createFilterOptions<ColumnT>({
+  stringify: option => `${option.id} ${option.attributes?.uiName || ""}`,
+})
+
 export const DimensionPicker: React.FC<{
   selectedDimension: ColumnT | undefined
   setDimensionID: Dispatch<string | undefined>
@@ -85,6 +89,7 @@ export const DimensionPicker: React.FC<{
 
   return (
     <Autocomplete<ColumnT, false, undefined, true>
+      filterOptions={columnFilterOptions}
       fullWidth
       autoComplete
       autoHighlight
@@ -130,6 +135,7 @@ export const DimensionsPicker: React.FC<{
 
   return (
     <Autocomplete<ColumnT, true, undefined, true>
+      filterOptions={columnFilterOptions}
       fullWidth
       autoComplete
       autoHighlight
@@ -176,6 +182,7 @@ export const MetricPicker: React.FC<{
 
   return (
     <Autocomplete<ColumnT, false, undefined, true>
+      filterOptions={columnFilterOptions}
       fullWidth
       autoComplete
       autoHighlight
@@ -223,6 +230,7 @@ export const MetricsPicker: React.FC<{
 
   return (
     <Autocomplete<ColumnT, true, undefined, true>
+      filterOptions={columnFilterOptions}
       fullWidth
       autoComplete
       autoHighlight
@@ -291,7 +299,9 @@ const Segment: React.FC<{
   )
 }
 
-const filter = createFilterOptions<SegmentT>()
+const segmentFilterOptions = createFilterOptions<SegmentT>({
+  stringify: option => `${option.segmentId} ${option.name}`,
+})
 export const SegmentPicker: React.FC<{
   segment: SegmentT | undefined
   setSegmentID: Dispatch<string | undefined>
@@ -330,7 +340,7 @@ export const SegmentPicker: React.FC<{
       getOptionLabel={getOptionLabel}
       value={segment || null}
       filterOptions={(options, params) => {
-        const filtered = filter(options || [], params)
+        const filtered = segmentFilterOptions(options || [], params)
 
         // Add entry for creating a dynamic segment based on input.
         if (params.inputValue !== "") {


### PR DESCRIPTION
Instead of relying on `getOptionLabel`, create a string to use for matching that includes all relevant/useful fields.

fixes #738 