### PR TITLE
Add TextBox to Event Builder

### DIFF
--- a/src/components/Buttons.tsx
+++ b/src/components/Buttons.tsx
@@ -65,12 +65,13 @@ export const PlainButton: React.FC<Props> = ({ ...props }) => {
 }
 
 export const TooltipIconButton: React.FC<{
-  tooltip: string
+  tooltip: any
   size?: "small" | "medium"
   className?: string
   disabled?: boolean
+  placement?: "bottom" | "left" | "right" | "top" | "bottom-end" | "bottom-start" | "left-end" | "left-start" | "right-end" | "right-start" | "top-end" | "top-start" | undefined
   onClick?: () => void
-}> = ({ tooltip, children, onClick, className, disabled, size = "small" }) => {
+}> = ({ tooltip, children, onClick, className, disabled, size = "small", placement='bottom'}) => {
   if (disabled) {
     return (
       <IconButton
@@ -84,7 +85,7 @@ export const TooltipIconButton: React.FC<{
     )
   }
   return (
-    <Tooltip title={tooltip}>
+    <Tooltip title={tooltip} placement={placement} leaveDelay={2000}>
       <IconButton onClick={onClick} size={size} className={className}>
         {children}
       </IconButton>

--- a/src/components/CampaignURLBuilder/index.tsx
+++ b/src/components/CampaignURLBuilder/index.tsx
@@ -22,7 +22,6 @@ import { GAVersion } from "@/constants"
 import TabPanel from "@/components/TabPanel"
 import WebURLBuilder from "./Web"
 import PlayURLBuilder from "./Play"
-import IOSURLBuilder from "./IOS"
 
 export enum URLBuilderType {
   Web = "web",

--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -1,0 +1,61 @@
+import React from "react"
+import { TextField } from "@material-ui/core"
+import ExternalLink from "./ExternalLink"
+
+export interface TextBoxProps {
+  href: string
+  linkTitle: string
+  value: string | undefined
+  label: string
+  onChange: (e: string) => void
+  helperText: string | JSX.Element
+  extraAction?: JSX.Element
+  required?: true
+  disabled?: boolean
+  id?: string
+}
+
+const TextBox: React.FC<TextBoxProps> = ({
+  href,
+  linkTitle,
+  label,
+  value,
+  onChange,
+  required,
+  helperText,
+  disabled,
+  extraAction,
+  id,
+}) => {
+  return (
+    <TextField
+      InputProps={{
+        endAdornment: (
+          <span
+            style={{
+              display: "inline-flex",
+            }}
+          >
+            {extraAction}
+            <ExternalLink href={href} title={linkTitle} hover />
+          </span>
+        ),
+      }}
+      id={id}
+      size="medium"
+      variant="outlined"
+      fullWidth
+      label={label}
+      value={value === undefined ? "" : value}
+      onChange={e => onChange(e.target.value)}
+      required={required}
+      helperText={helperText}
+      disabled={disabled}
+      multiline={true}
+      maxRows={15}
+      minRows={15}
+    />
+  )
+}
+
+export default TextBox

--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -5,7 +5,7 @@ import ExternalLink from "./ExternalLink"
 export interface TextBoxProps {
   href: string
   linkTitle: string
-  value: string | undefined
+  value: string | undefined | object
   label: string
   onChange: (e: string) => void
   helperText: string | JSX.Element

--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -8,7 +8,7 @@ export interface TextBoxProps {
   value: string | undefined | object
   label: string
   onChange: (e: string) => void
-  helperText: string | JSX.Element
+  helperText?: string | JSX.Element
   extraAction?: JSX.Element
   required?: true
   disabled?: boolean

--- a/src/components/ga4/EventBuilder/ValidateEvent/handlers/formatCheckLib.spec.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/handlers/formatCheckLib.spec.ts
@@ -6,8 +6,9 @@ describe("formatCheckLib", () => {
         test("does not return an error when app_instance_id is 32 alpha-numeric chars", () => {
             const payload = {app_instance_id: "12345678901234567890123456789012"}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors).toEqual([])
         })
@@ -16,8 +17,9 @@ describe("formatCheckLib", () => {
             const appInstanceId = "123456789012345678901234567890123"
             const payload = {app_instance_id: appInstanceId}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors[0].description).toEqual(
                 `Measurement app_instance_id is expected to be a 32 digit hexadecimal number but was [${ appInstanceId.length }] digits.`
@@ -28,8 +30,9 @@ describe("formatCheckLib", () => {
             const appInstanceId = "1234567890123456789012345678901g"
             const payload = {app_instance_id: appInstanceId}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors[0].description).toEqual(
                 `Measurement app_instance_id contains non hexadecimal character [g].`,
@@ -41,8 +44,9 @@ describe("formatCheckLib", () => {
         test("does not return an error for a valid event name", () => {
             const payload = {events: [{name: 'add_payment_info'}]}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors).toEqual([])
         })
@@ -50,8 +54,9 @@ describe("formatCheckLib", () => {
         test("returns an error when event's name is a reserved name", () => {
             const payload = {events: [{name: 'ad_click'}]}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors[0].description).toEqual(
                 "ad_click is a reserved event name"
@@ -63,8 +68,9 @@ describe("formatCheckLib", () => {
         test("does not return an error for a valid user property name", () => {
             const payload = {user_properties: {'test': 'test'}}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors).toEqual([])
         })
@@ -72,8 +78,9 @@ describe("formatCheckLib", () => {
         test("returns an error when event's name is a reserved name", () => {
             const payload = {user_properties: {'first_open_time': 'test'}}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors[0].description).toEqual(
                 "user_property: 'first_open_time' is a reserved user property name"
@@ -85,8 +92,9 @@ describe("formatCheckLib", () => {
         test("does not return an error for a valid currency type", () => {
             const payload = {events: [{params: {currency: 'USD'}}]}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors).toEqual([])
         })
@@ -94,8 +102,9 @@ describe("formatCheckLib", () => {
         test("returns an error for an invalid currency type", () => {
             const payload = {events: [{params: {currency: 'USDD'}}]}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors[0].description).toEqual(
                 "currency: USDD must be a valid uppercase 3-letter ISO 4217 format"
@@ -107,8 +116,9 @@ describe("formatCheckLib", () => {
         test("does not return an error if items array is valid", () => {
             const payload = {events: [{params: {items: [{'item_id': 1234}]}}]}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors).toEqual([])
         })
@@ -116,8 +126,9 @@ describe("formatCheckLib", () => {
         test("returns an error when items does not have either item_id or item_name", () => {
             const payload = {events: [{params: {items: [{'item_namee': 'test'}]}}]}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors[0].description).toEqual(
                 "'items' object must contain one of the following keys: 'item_id' or 'item_name'"
@@ -127,8 +138,9 @@ describe("formatCheckLib", () => {
         test("validates empty items array when event requires items", () => {
             const payload = {events: [{params: {name: 'purchase', items: []}}]}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors[0].description).toEqual(
                 "'items' should not be empty; One of 'item_id' or 'item_name' is a required key"
@@ -138,8 +150,9 @@ describe("formatCheckLib", () => {
         test("does not validate empty items array when event doesn't require items", () => {
             const payload = {events: [{params: {name: 'random', items: []}}]}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors).toEqual([])
         })
@@ -147,8 +160,9 @@ describe("formatCheckLib", () => {
         test("does not validate empty items array when event does not have a name", () => {
             const payload = {events: [{params: {items: []}}]}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors).toEqual([])
         })
@@ -169,8 +183,9 @@ describe("formatCheckLib", () => {
                 ] 
             }
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors[0].description).toEqual(
                 "'items' object must contain one of the following keys: 'item_id' or 'item_name'"
@@ -182,8 +197,9 @@ describe("formatCheckLib", () => {
         test("does not return an error if firebase_app_id is valid", () => {
             const payload = {}
             const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors).toEqual([])
         })
@@ -191,11 +207,36 @@ describe("formatCheckLib", () => {
         test("returns an error when firebase_app_id is invalid", () => {
             const payload = {}
             const firebaseAppId = '1233455666:android:abcdefgh'
+            const api_secret = '123'
 
-            let errors = formatCheckLib(payload, firebaseAppId)
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
 
             expect(errors[0].description).toEqual(
                 `${firebaseAppId} does not follow firebase_app_id pattern of X:XX:XX:XX at path`
+            )
+        })
+    })
+
+    describe("validates api_secret", () => {
+        test("does not return an error api_secret is not null", () => {
+            const payload = {}
+            const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = '123'
+
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
+
+            expect(errors).toEqual([])
+        })
+
+        test("returns an error when api_secret is null", () => {
+            const payload = {}
+            const firebaseAppId = '1:1233455666:android:abcdefgh'
+            const api_secret = ''
+
+            let errors = formatCheckLib(payload, firebaseAppId, api_secret)
+
+            expect(errors[0].description).toEqual(
+                "Unable to find non-empty parameter [api_secret] value in request."
             )
         })
     })

--- a/src/components/ga4/EventBuilder/ValidateEvent/handlers/formatCheckLib.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/handlers/formatCheckLib.ts
@@ -183,7 +183,7 @@ const requiredKeysEmpty = (itemsObj) => {
 const isfirebaseAppIdValid = (firebaseAppId) => {
     let errors: ValidationMessage[] = []
 
-    if (!firebaseAppId.match(/[0-9]:[0-9]+:[a-zA-Z]+:[a-zA-Z0-9]+$/)) {
+    if (firebaseAppId && !firebaseAppId.match(/[0-9]:[0-9]+:[a-zA-Z]+:[a-zA-Z0-9]+$/)) {
         errors.push({
             description: `${firebaseAppId} does not follow firebase_app_id pattern of X:XX:XX:XX at path`,
             validationCode: "value_invalid",

--- a/src/components/ga4/EventBuilder/ValidateEvent/handlers/formatCheckLib.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/handlers/formatCheckLib.ts
@@ -18,7 +18,7 @@ const RESERVED_USER_PROPERTY_NAMES = [
 
 // formatCheckLib provides additional validations for payload not included in 
 // the schema validations. All checks are consistent with Firebase documentation.
-export const formatCheckLib = (payload, firebaseAppId) => {
+export const formatCheckLib = (payload, firebaseAppId, api_secret) => {
     let errors: ValidationMessage[] = []
 
     const appInstanceIdErrors = isValidAppInstanceId(payload)
@@ -28,6 +28,7 @@ export const formatCheckLib = (payload, firebaseAppId) => {
     const emptyItemsErrors = isItemsEmpty(payload)
     const itemsRequiredKeyErrors = itemsHaveRequiredKey(payload)
     const firebaseAppIdErrors = isfirebaseAppIdValid(firebaseAppId)
+    const apiSecretErrors = isApiSecretNotNull(api_secret)
     const sizeErrors = isTooBig(payload)
 
     return [
@@ -39,6 +40,7 @@ export const formatCheckLib = (payload, firebaseAppId) => {
         ...emptyItemsErrors,
         ...itemsRequiredKeyErrors,
         ...firebaseAppIdErrors,
+        ...apiSecretErrors,
         ...sizeErrors,
     ]
 }
@@ -188,6 +190,20 @@ const isfirebaseAppIdValid = (firebaseAppId) => {
             description: `${firebaseAppId} does not follow firebase_app_id pattern of X:XX:XX:XX at path`,
             validationCode: "value_invalid",
             fieldPath: "firebase_app_id"
+        })
+    }
+
+    return errors
+}
+
+const isApiSecretNotNull = (api_secret) => {
+    let errors: ValidationMessage[] = []
+
+    if (!api_secret) {
+        errors.push({
+            description: "Unable to find non-empty parameter [api_secret] value in request.",
+            validationCode: "VALUE_REQUIRED",
+            fieldPath: "api_secret"
         })
     }
 

--- a/src/components/ga4/EventBuilder/ValidateEvent/handlers/formatCheckLib.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/handlers/formatCheckLib.ts
@@ -17,7 +17,7 @@ const RESERVED_USER_PROPERTY_NAMES = [
 ]
 
 // formatCheckLib provides additional validations for payload not included in 
-// the schema validations. All checks are consistent with Firebase documentation
+// the schema validations. All checks are consistent with Firebase documentation.
 export const formatCheckLib = (payload, firebaseAppId) => {
     let errors: ValidationMessage[] = []
 

--- a/src/components/ga4/EventBuilder/ValidateEvent/handlers/responseUtil.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/handlers/responseUtil.ts
@@ -8,6 +8,7 @@ const API_DOC_BASE_PAYLOAD_URL = 'https://developers.google.com/analytics/devgui
 const API_DOC_EVENT_URL = 'https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#'
 const API_DOC_USER_PROPERTIES = 'https://developers.google.com/analytics/devguides/collection/protocol/ga4/user-properties?hl=en&client_type=firebase'
 const API_DOC_SENDING_EVENTS_URL = 'https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?hl=en&client_type=firebase'
+const API_DOC_JSON_POST_BODY = 'https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?hl=en&client_type=firebase#payload_post_body'
 
 const BASE_PAYLOAD_ATTRIBUTES = ['app_instance_id', 'api_secret', 'firebase_app_id', 'user_id', 'timestamp_micros', 'user_properties', 'non_personalized_ads']
 
@@ -59,4 +60,13 @@ const addDocumentation = (error, payload) => {
     }
 
     return API_DOC_SENDING_EVENTS_URL
+}
+
+export const formatValidationMessage = () => {
+    return [{
+        'description': 'Fix formatting issue and re-validate payload by clicking `Validate Event` below',
+        'validationCode': 'format_invalid',
+        'fieldPath': '#',
+        'documentation': API_DOC_JSON_POST_BODY
+    }]
 }

--- a/src/components/ga4/EventBuilder/ValidateEvent/handlers/responseUtil.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/handlers/responseUtil.ts
@@ -27,7 +27,7 @@ export const formatErrorMessages = (errors, payload) => {
             error['description'] = description.slice(0, end_index) + ALPHA_NUMERIC_OVERRIDE
 
             return error
-        } else if (BASE_PAYLOAD_ATTRIBUTES.includes(fieldPath.slice(2))) {
+        } else if (BASE_PAYLOAD_ATTRIBUTES.includes(fieldPath?.slice(2))) {
             error['fieldPath'] = fieldPath.slice(2)
 
             return error
@@ -50,7 +50,7 @@ const addDocumentation = (error, payload) => {
 
     if (validationCode === 'max-length-error' || validationCode === 'max-properties-error' || validationCode === 'max-body-size') {
         return API_DOC_LIMITATIONS_URL
-    } else if (fieldPath.startsWith('#/events/')) {
+    } else if (fieldPath?.startsWith('#/events/')) {
         return API_DOC_EVENT_URL + payload?.events[0]?.name
     } else if (BASE_PAYLOAD_ATTRIBUTES.includes(fieldPath)) {
         return API_DOC_BASE_PAYLOAD_URL + fieldPath

--- a/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
+++ b/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
@@ -51,6 +51,7 @@ interface TemplateProps {
   valid?: boolean
   sent?: boolean
   payloadErrors?: string | undefined
+  useTextBox?: boolean
 }
 
 export interface ValidateEventProps {
@@ -62,6 +63,7 @@ export interface ValidateEventProps {
   user_id: string
   formatPayload: () => void
   payloadErrors: string | undefined
+  useTextBox: boolean
 }
 
 const useStyles = makeStyles(theme => ({
@@ -97,12 +99,12 @@ const useStyles = makeStyles(theme => ({
 }))
 
 
-const focusFor = (message: ValidationMessage) => {
+const focusFor = (message: ValidationMessage, useTextBox) => {
   const { fieldPath } = message
   let id: string | undefined
   let labelValues: string[] = Object.values(Label)
 
-  if (labelValues.includes(fieldPath)) {
+  if (labelValues.includes(fieldPath) && !useTextBox) {
     id = fieldPath
   }
 
@@ -134,7 +136,8 @@ const Template: React.FC<TemplateProps> = ({
   copySharableLink,
   error,
   valid,
-  payloadErrors
+  payloadErrors,
+  useTextBox
 }) => {
   const { instanceId, api_secret } = useContext(EventCtx)!
   const classes = useStyles({ error, valid })
@@ -156,7 +159,7 @@ const Template: React.FC<TemplateProps> = ({
           {validationMessages.map((message, idx) => (
             <div>
               <li key={idx}>
-                {focusFor(message)}
+                {focusFor(message, useTextBox)}
                 {message.description}
                 <br />
                 <a href={message.documentation} target='_blank'>Documentation</a>
@@ -231,7 +234,7 @@ const Template: React.FC<TemplateProps> = ({
   )
 }
 
-const ValidateEvent: React.FC<ValidateEventProps> = ({formatPayload, payloadErrors}) => {
+const ValidateEvent: React.FC<ValidateEventProps> = ({formatPayload, payloadErrors, useTextBox}) => {
   const request = useValidateEvent()
 
   return (
@@ -284,6 +287,7 @@ const ValidateEvent: React.FC<ValidateEventProps> = ({formatPayload, payloadErro
           }
           validationMessages={validationMessages}
           payloadErrors={payloadErrors}
+          useTextBox={useTextBox}
         />
       )}
       renderSuccessful={({ sendToGA, copyPayload, copySharableLink, sent }) => (

--- a/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
+++ b/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
@@ -152,7 +152,11 @@ const Template: React.FC<TemplateProps> = ({
         {heading}
       </Typography>
 
-      {validationMessages !== undefined && !payloadErrors && (
+      {validationMessages !== undefined && 
+        (
+          (useTextBox && !payloadErrors) ||
+          !useTextBox 
+        ) && (
         <ul>
           {validationMessages.map((message, idx) => (
             <div>
@@ -169,7 +173,7 @@ const Template: React.FC<TemplateProps> = ({
         </ul>
       )}
 
-      {validationMessages !== undefined && payloadErrors && (
+      {useTextBox && payloadErrors && (
         <div>
           <ul>
             <li>

--- a/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
+++ b/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
@@ -22,11 +22,9 @@ import useValidateEvent from "./useValidateEvent"
 import Loadable from "@/components/Loadable"
 import Typography from "@material-ui/core/Typography"
 import { PAB, PlainButton } from "@/components/Buttons"
-import { Check, Warning, Error as ErrorIcon, ContactSupportOutlined } from "@material-ui/icons"
+import { Check, Warning, Error as ErrorIcon } from "@material-ui/icons"
 import PrettyJson from "@/components/PrettyJson"
 import usePayload from "./usePayload"
-import useInputs from "../useInputs"
-import useEvent from "../useEvent"
 import { ValidationMessage } from "../types"
 import Spinner from "@/components/Spinner"
 import { EventCtx, Label } from ".."
@@ -172,11 +170,15 @@ const Template: React.FC<TemplateProps> = ({
       )}
 
       {validationMessages !== undefined && payloadErrors && (
-        <h3
-          style={{color: 'purple'}}
-        >
-          {payloadErrors}
-        </h3>
+        <div>
+          <ul>
+            <li>
+              JSON formatting error: <i>{payloadErrors}</i>
+            </li>
+          </ul>
+          <br/>
+          <br/>
+        </div>
       )}
 
       {body}

--- a/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
+++ b/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
@@ -126,10 +126,13 @@ const Template: React.FC<TemplateProps> = ({
   error,
   valid,
 }) => {
+  const { instanceId, api_secret, inputPayload, useTextBox } = useContext(EventCtx)!
   const classes = useStyles({ error, valid })
+  // const payload = useTextBox ? inputPayload : usePayload()
   const payload = usePayload()
+  // payload is parsed through usePayload. We can just say payload = usePayload || textbox
+  // must also add formatting of textbox
   const formClasses = useFormStyles()
-  const { instanceId, api_secret } = useContext(EventCtx)!
   return (
     <Card
       className={clsx(formClasses.form, classes.template)}
@@ -217,6 +220,7 @@ const ValidateEvent: React.FC<ValidateEventProps> = () => {
             <>
               <Typography>
                 Update the event using the controls above.
+                # should update this language!
               </Typography>
               <Typography>
                 When you're done editing the event, click "Validate Event" to

--- a/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
+++ b/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
@@ -133,9 +133,12 @@ const Template: React.FC<TemplateProps> = ({
   valid,
   formatPayload,
 }) => {
-  const { instanceId, api_secret } = useContext(EventCtx)!
+  const { instanceId, api_secret, useTextBox, payloadObj } = useContext(EventCtx)!
   const classes = useStyles({ error, valid })
-  // const payload = useTextBox ? inputPayload : usePayload()
+  // console.log('useTextbox', useTextBox)
+  // console.log('payloadObj', payloadObj)
+  // const payload = useTextBox ? payloadObj : usePayload()
+  // console.log('payload', payload)
   const payload = usePayload()
   // payload is parsed through usePayload. We can just say payload = usePayload || textbox
   const formClasses = useFormStyles()
@@ -172,10 +175,11 @@ const Template: React.FC<TemplateProps> = ({
         {validateEvent !== undefined && (
           <PAB small onClick={() => {
             console.log('validate second time')
-            // need to format second time here
+            // only do this for textBox
             if (formatPayload) {
               formatPayload()
             }
+            // only validate event if formatted correctly (if is textbox)
             validateEvent()
           }
           }>

--- a/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
+++ b/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
@@ -288,7 +288,7 @@ const ValidateEvent: React.FC<ValidateEventProps> = ({formatPayload, payloadErro
           useTextBox={useTextBox}
         />
       )}
-      renderSuccessful={({ sendToGA, copyPayload, copySharableLink, sent }) => (
+      renderSuccessful={({ sendToGA, copyPayload, copySharableLink, sent}) => (
         <Template
           sent={sent}
           valid

--- a/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
+++ b/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
@@ -30,6 +30,8 @@ import Spinner from "@/components/Spinner"
 import { EventCtx, Label } from ".."
 import { Card } from "@material-ui/core"
 import { green, red } from "@material-ui/core/colors"
+import useInputs from "../useInputs" 
+import useEvent from "../useEvent"
 
 interface StyleProps {
   error?: boolean
@@ -74,6 +76,7 @@ export interface ValidateEventProps {
   api_secret: string
   client_id: string
   user_id: string
+  payloadObj: object
 }
 
 const focusFor = (message: ValidationMessage) => {
@@ -113,6 +116,7 @@ interface TemplateProps {
   valid?: boolean
   sent?: boolean
 }
+
 const Template: React.FC<TemplateProps> = ({
   sent,
   heading,
@@ -126,13 +130,14 @@ const Template: React.FC<TemplateProps> = ({
   error,
   valid,
 }) => {
-  const { instanceId, api_secret, inputPayload, useTextBox } = useContext(EventCtx)!
+  const { instanceId, api_secret } = useContext(EventCtx)!
   const classes = useStyles({ error, valid })
   // const payload = useTextBox ? inputPayload : usePayload()
   const payload = usePayload()
   // payload is parsed through usePayload. We can just say payload = usePayload || textbox
   // must also add formatting of textbox
   const formClasses = useFormStyles()
+
   return (
     <Card
       className={clsx(formClasses.form, classes.template)}
@@ -206,8 +211,11 @@ const Template: React.FC<TemplateProps> = ({
   )
 }
 
-const ValidateEvent: React.FC<ValidateEventProps> = () => {
+const ValidateEvent: React.FC<ValidateEventProps> = ({payloadObj}) => {
   const request = useValidateEvent()
+  console.log('payloadObj', payloadObj)
+  // const { categories } = useEvent()
+  // const { inputPayload, payloadObj, setPayloadObj, setPayloadErrors } = useInputs(categories)
 
   return (
     <Loadable
@@ -228,7 +236,12 @@ const ValidateEvent: React.FC<ValidateEventProps> = () => {
               </Typography>
             </>
           }
-          validateEvent={validateEvent}
+          validateEvent={ () => {
+            console.log('here')
+              // formatPayload()
+              validateEvent()
+            }
+          }
         />
       )}
       renderInProgress={() => (

--- a/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
+++ b/src/components/ga4/EventBuilder/ValidateEvent/index.tsx
@@ -257,7 +257,6 @@ const ValidateEvent: React.FC<ValidateEventProps> = ({formatPayload, payloadErro
             </>
           }
           validateEvent={ () => {
-              console.log('validate first time')
               if (formatPayload) {
                 formatPayload()
               }
@@ -277,7 +276,6 @@ const ValidateEvent: React.FC<ValidateEventProps> = ({formatPayload, payloadErro
           heading="Event is invalid"
           body=""
           validateEvent={ () => {
-              console.log('validate second time')
               if (formatPayload) {
                 formatPayload()
               }

--- a/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
@@ -71,6 +71,7 @@ const usePayload = (): {} => {
     clientIds,
     type,
     useTextBox,
+    payloadObj
   } = useContext(EventCtx)!
 
   const eventName = useMemo(() => {
@@ -123,7 +124,14 @@ const usePayload = (): {} => {
   ])
 
   if (useTextBox) {
-    // payload = payloadO? jsonifyPayload(inputPayload) : undefined
+    console.log(typeof payloadObj)
+    console.log('payo', payloadObj)
+
+    if ((typeof payloadObj) === 'string') {
+      payload = JSON.parse(payloadObj)
+    } else {
+      payload = payloadObj
+    }
   }
 
   return payload

--- a/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
@@ -70,6 +70,8 @@ const usePayload = (): {} => {
     non_personalized_ads,
     clientIds,
     type,
+    inputPayload,
+    useTextBox
   } = useContext(EventCtx)!
 
   const eventName = useMemo(() => {
@@ -100,8 +102,16 @@ const usePayload = (): {} => {
     () => userProperties.reduce(objectifyUserProperties, {}),
     [userProperties]
   )
+  
+  const jsonifyPayload = (payload) => {
+    // need to figure out a way not to error if invalid payload...
+    // console.log('payload', payload)
+    // console.log('payload string', String(payload))
 
-  const payload = useMemo(() => {
+    return JSON.parse(String(payload))
+  }
+
+  let payload = useMemo(() => {
     return {
       ...removeUndefined(clientIds),
       ...removeUndefined({ timestamp_micros }),
@@ -120,6 +130,10 @@ const usePayload = (): {} => {
     timestamp_micros,
     user_properties,
   ])
+
+//   if (useTextBox) {
+//     payload = inputPayload ? jsonifyPayload(inputPayload) : undefined
+//   }
 
   return payload
 }

--- a/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
@@ -124,9 +124,6 @@ const usePayload = (): {} => {
   ])
 
   if (useTextBox) {
-    console.log(typeof payloadObj)
-    console.log('payo', payloadObj)
-
     if ((typeof payloadObj) === 'string') {
       payload = JSON.parse(payloadObj)
     } else {

--- a/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
@@ -102,14 +102,6 @@ const usePayload = (): {} => {
     [userProperties]
   )
   
-  const jsonifyPayload = (payload) => {
-    // need to figure out a way not to error if invalid payload...
-    // console.log('payload', payload)
-    // console.log('payload string', String(payload))
-
-    return JSON.parse(String(payload))
-  }
-
   let payload = useMemo(() => {
     return {
       ...removeUndefined(clientIds),

--- a/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
@@ -70,8 +70,7 @@ const usePayload = (): {} => {
     non_personalized_ads,
     clientIds,
     type,
-    inputPayload,
-    useTextBox
+    useTextBox,
   } = useContext(EventCtx)!
 
   const eventName = useMemo(() => {
@@ -131,9 +130,9 @@ const usePayload = (): {} => {
     user_properties,
   ])
 
-//   if (useTextBox) {
-//     payload = inputPayload ? jsonifyPayload(inputPayload) : undefined
-//   }
+  if (useTextBox) {
+    // payload = payloadO? jsonifyPayload(inputPayload) : undefined
+  }
 
   return payload
 }

--- a/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
@@ -125,7 +125,11 @@ const usePayload = (): {} => {
 
   if (useTextBox) {
     if ((typeof payloadObj) === 'string') {
-      payload = JSON.parse(payloadObj)
+      if (Object.keys(payloadObj).length === 0) {
+        payload = {}
+      } else {
+        payload = JSON.parse(payloadObj)
+      }
     } else {
       payload = payloadObj
     }

--- a/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
@@ -126,6 +126,7 @@ const usePayload = (): {} => {
   if (useTextBox) {
     if ((typeof payloadObj) === 'string') {
       if (Object.keys(payloadObj).length === 0) {
+        // @ts-ignore ts[2741]
         payload = {}
       } else {
         payload = JSON.parse(payloadObj)

--- a/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
@@ -127,6 +127,29 @@ const useValidateEvent = (): Requestable<
 
   const copySharableLink = useCopy(url, "copied link to event")
 
+  const validatePayloadAttributes = (payload) => {
+    let validator = new Validator(baseContentSchema)
+    let formatCheckErrors: ValidationMessage[] | [] = formatCheckLib(
+      payload, 
+      instanceId?.firebase_app_id,
+      api_secret
+    )
+
+    if (!validator.isValid(payload) || formatCheckErrors) {
+      let validatorErrors: ValidationMessage[] = validator.getErrors(payload).map((err) => {
+        return {
+          description: err.message,
+          validationCode: err?.data?.validationError?.code ? err?.data?.validationError?.code : err.code,
+          fieldPath: defineFieldCode(err)
+        }
+      })
+
+      return [...validatorErrors, ...formatCheckErrors]
+    }
+
+    return []
+  }
+
   const validateEvent = useCallback(() => {
     if (status === RequestStatus.InProgress) {
       return
@@ -172,30 +195,7 @@ const useValidateEvent = (): Requestable<
       setValidationMessages(validatorErrors)
       setStatus(RequestStatus.Failed)
     }
-  }, [status, payload, api_secret, instanceId, useFirebase, payloadErrors])
-
-  const validatePayloadAttributes = (payload) => {
-    let validator = new Validator(baseContentSchema)
-    let formatCheckErrors: ValidationMessage[] | [] = formatCheckLib(
-      payload, 
-      instanceId?.firebase_app_id,
-      api_secret
-    )
-
-    if (!validator.isValid(payload) || formatCheckErrors) {
-      let validatorErrors: ValidationMessage[] = validator.getErrors(payload).map((err) => {
-        return {
-          description: err.message,
-          validationCode: err?.data?.validationError?.code ? err?.data?.validationError?.code : err.code,
-          fieldPath: defineFieldCode(err)
-        }
-      })
-
-      return [...validatorErrors, ...formatCheckErrors]
-    }
-
-    return []
-  }
+  }, [status, payload, api_secret, instanceId, useFirebase, payloadErrors, useTextBox, validatePayloadAttributes])
 
   const defineFieldCode = (error) => {
     const { data } = error

--- a/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
@@ -110,6 +110,7 @@ const useValidateEvent = (): Requestable<
     }
   }, [payload, useTextBox])
 
+
   const sendToGA = useCallback(() => {
     if (status !== RequestStatus.Successful) {
       return
@@ -133,7 +134,7 @@ const useValidateEvent = (): Requestable<
     setStatus(RequestStatus.InProgress)
     setValidationMessages([])
 
-    if (Object.keys(payload).length !== 0) {
+    if (!useTextBox || Object.keys(payload).length !== 0) {
       let validatorErrors = useFirebase ? validatePayloadAttributes(payload) : []
 
       validateHit(payload, instanceId, api_secret)

--- a/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
@@ -108,7 +108,7 @@ const useValidateEvent = (): Requestable<
       setStatus(RequestStatus.NotStarted)
       setSent(false)
     }
-  }, [payload])
+  }, [payload, useTextBox])
 
   const sendToGA = useCallback(() => {
     if (status !== RequestStatus.Successful) {

--- a/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
@@ -95,13 +95,18 @@ const useValidateEvent = (): Requestable<
   >([])
   const payload = usePayload()
   const [sent, setSent] = useState(false)
+  // figure out how instanceId is parsed. Is it from payload or somewhere else?
+  // this might not actually matter as long as instanceId is added to payload? 
+  // SHould verify. Should only need to enter firebase id in textbox and then 
+  // instance id should be part of payload
   const { instanceId, api_secret } = useContext(EventCtx)!
 
   // Whenever the payload changes, we start the "request" over.
-  useEffect(() => {
-    setStatus(RequestStatus.NotStarted)
-    setSent(false)
-  }, [payload])
+  // THIS IS WHY NOT WORKING FOR PAYLOAD TEXTBOX
+  // useEffect(() => {
+  //   setStatus(RequestStatus.NotStarted)
+  //   setSent(false)
+  // }, [payload])
 
   const sendToGA = useCallback(() => {
     if (status !== RequestStatus.Successful) {
@@ -146,9 +151,9 @@ const useValidateEvent = (): Requestable<
             })
 
             validatorErrors = formatErrorMessages(validatorErrors, payload)
-            console.log('validatorErrors', validatorErrors)
             
             setValidationMessages(validatorErrors)
+            // why isn;t this working?!
             setStatus(RequestStatus.Failed)
           } else {
             setStatus(RequestStatus.Successful)

--- a/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
@@ -157,7 +157,6 @@ const useValidateEvent = (): Requestable<
               validatorErrors = formatErrorMessages(validatorErrors, payload)
               
               setValidationMessages(validatorErrors)
-              console.log('validatorErrors', validatorErrors)
               setStatus(RequestStatus.Failed)
             } else {
               setStatus(RequestStatus.Successful)
@@ -171,7 +170,6 @@ const useValidateEvent = (): Requestable<
       let validatorErrors = formatValidationMessage()
       setValidationMessages(validatorErrors)
       setStatus(RequestStatus.Failed)
-      console.log('FORMAT ERROR')
     }
   }, [status, payload, api_secret, instanceId, useFirebase, payloadErrors])
 

--- a/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
@@ -89,11 +89,12 @@ const useValidateEvent = (): Requestable<
   ValidationFailed
 > => {
   const useFirebase = useContext(UseFirebaseCtx)
+  const { useTextBox } = useContext(EventCtx)!
   const [status, setStatus] = useState(RequestStatus.NotStarted)
   const [validationMessages, setValidationMessages] = useState<
     ValidationMessage[]
   >([])
-  const payload = usePayload()
+  let payload = usePayload()
   const [sent, setSent] = useState(false)
   // figure out how instanceId is parsed. Is it from payload or somewhere else?
   // this might not actually matter as long as instanceId is added to payload? 
@@ -103,10 +104,12 @@ const useValidateEvent = (): Requestable<
 
   // Whenever the payload changes, we start the "request" over.
   // THIS IS WHY NOT WORKING FOR PAYLOAD TEXTBOX
-  // useEffect(() => {
-  //   setStatus(RequestStatus.NotStarted)
-  //   setSent(false)
-  // }, [payload])
+  useEffect(() => {
+    if (!useTextBox) {
+      setStatus(RequestStatus.NotStarted)
+    }
+    setSent(false)
+  }, [payload])
 
   const sendToGA = useCallback(() => {
     if (status !== RequestStatus.Successful) {
@@ -153,7 +156,7 @@ const useValidateEvent = (): Requestable<
             validatorErrors = formatErrorMessages(validatorErrors, payload)
             
             setValidationMessages(validatorErrors)
-            // why isn;t this working?!
+            // why isn't this working?!
             setStatus(RequestStatus.Failed)
           } else {
             setStatus(RequestStatus.Successful)
@@ -166,6 +169,7 @@ const useValidateEvent = (): Requestable<
   }, [status, payload, api_secret, instanceId, useFirebase])
 
   const validatePayloadAttributes = (payload) => {
+    console.log('payload in validatePayloadAttribute', payload)
     let validator = new Validator(baseContentSchema)
     let formatCheckErrors: ValidationMessage[] | [] = formatCheckLib(payload, instanceId?.firebase_app_id)
 

--- a/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
@@ -176,7 +176,11 @@ const useValidateEvent = (): Requestable<
 
   const validatePayloadAttributes = (payload) => {
     let validator = new Validator(baseContentSchema)
-    let formatCheckErrors: ValidationMessage[] | [] = formatCheckLib(payload, instanceId?.firebase_app_id)
+    let formatCheckErrors: ValidationMessage[] | [] = formatCheckLib(
+      payload, 
+      instanceId?.firebase_app_id,
+      api_secret
+    )
 
     if (!validator.isValid(payload) || formatCheckErrors) {
       let validatorErrors: ValidationMessage[] = validator.getErrors(payload).map((err) => {

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -23,6 +23,7 @@ import Autocomplete from "@material-ui/lab/Autocomplete"
 import Refresh from "@material-ui/icons/Refresh"
 
 import LinkedTextField from "@/components/LinkedTextField"
+import TextBox from "@/components/TextBox"
 import LabeledCheckbox from "@/components/LabeledCheckbox"
 import Grid from "@material-ui/core/Grid"
 import Switch from "@material-ui/core/Switch"
@@ -31,6 +32,7 @@ import { Url } from "@/constants"
 import WithHelpText from "@/components/WithHelpText"
 import useFormStyles from "@/hooks/useFormStyles"
 import useEvent from "./useEvent"
+import { formatPayload } from "./useEvent"
 import Parameters from "./Parameters"
 import useInputs from "./useInputs"
 import { Category, ClientIds, EventType, InstanceId, Parameter } from "./types"
@@ -38,6 +40,7 @@ import { eventsForCategory } from "./event"
 import useUserProperties from "./useUserProperties"
 import Items from "./Items"
 import ValidateEvent from "./ValidateEvent"
+import { Button } from "@material-ui/core"
 
 export enum Label {
   APISecret = "api_secret",
@@ -118,6 +121,8 @@ export const EventCtx = React.createContext<
       clientIds: ClientIds
       instanceId: InstanceId
       api_secret: string
+      inputPayload: string | undefined
+      useTextBox: boolean
     }
   | undefined
 >(undefined)
@@ -163,6 +168,10 @@ const EventBuilder: React.FC = () => {
   const {
     useFirebase,
     setUseFirebase,
+    useTextBox,
+    setUseTextBox,
+    inputPayload,
+    setInputPayload,
     category,
     setCategory,
     api_secret,
@@ -223,6 +232,54 @@ const EventBuilder: React.FC = () => {
         After choosing a client, fill out the inputs below.
       </Typography>
 
+
+    { 
+      useFirebase && (
+      <WithHelpText
+        notched
+        shrink
+        label="format"
+        className="formatTab"
+      >
+        <Grid component="label" container alignItems="center" spacing={1}>
+          <Grid item>form</Grid>
+          <Grid item>
+            <Switch
+              data-testid="use form"
+              checked={useTextBox}
+              onChange={e => {
+                setUseTextBox(e.target.checked)
+              }}
+              name="use form"
+              color="primary"
+            />
+          </Grid>
+          <Grid item>text box</Grid>
+        </Grid>
+      </WithHelpText>
+      )
+    }
+
+    { useTextBox && 
+      <div>
+        <TextBox
+          required
+          href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference#api_secret"
+          linkTitle="Enter payload here"
+          value={inputPayload || ""}
+          label={Label.Payload}
+          helperText="Payload"
+          onChange={setInputPayload}
+        />
+        <Button
+          onClick={() => formatPayload(inputPayload)}
+        >
+          format payload
+        </Button>
+      </div>
+    }
+      { !useTextBox && 
+      <div>
       <section className={formClasses.form}>
         <LinkedTextField
           required
@@ -477,6 +534,8 @@ const EventBuilder: React.FC = () => {
           )}
         </ShowAdvancedCtx.Provider>
       </section>
+      </div>
+      }
 
       <Typography variant="h3" className={classes.validateHeading}>
         Validate & Send event
@@ -494,6 +553,8 @@ const EventBuilder: React.FC = () => {
             userProperties,
             timestamp_micros,
             non_personalized_ads,
+            useTextBox,
+            inputPayload,
             instanceId: useFirebase ? { firebase_app_id } : { measurement_id },
             api_secret: api_secret!,
           }}

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -336,8 +336,8 @@ const EventBuilder: React.FC = () => {
 
         <TextBox
           required
-          href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference#api_secret"
-          linkTitle="Enter payload here"
+          href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload_post_body"
+          linkTitle="JSON Payload Documentation"
           value={Object.keys(payloadObj).length > 0 ? payloadObj : inputPayload}
           label={Label.Payload}
           onChange={(input) => {

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -18,6 +18,7 @@ import makeStyles from "@material-ui/core/styles/makeStyles"
 import Typography from "@material-ui/core/Typography"
 import TextField from "@material-ui/core/TextField"
 import IconButton from "@material-ui/core/IconButton"
+import { Error as ErrorIcon } from "@material-ui/icons"
 import Tooltip from "@material-ui/core/Tooltip"
 import Autocomplete from "@material-ui/lab/Autocomplete"
 import Refresh from "@material-ui/icons/Refresh"
@@ -31,6 +32,7 @@ import ExternalLink from "@/components/ExternalLink"
 import { Url } from "@/constants"
 import WithHelpText from "@/components/WithHelpText"
 import useFormStyles from "@/hooks/useFormStyles"
+import { TooltipIconButton } from "@/components/Buttons"
 import useEvent from "./useEvent"
 import Parameters from "./Parameters"
 import useInputs from "./useInputs"
@@ -39,7 +41,7 @@ import { eventsForCategory } from "./event"
 import useUserProperties from "./useUserProperties"
 import Items from "./Items"
 import ValidateEvent from "./ValidateEvent"
-import { Button } from "@material-ui/core"
+import { PlainButton } from "@/components/Buttons"
 import { useEffect } from "react"
 
 export enum Label {
@@ -265,36 +267,38 @@ const EventBuilder: React.FC = () => {
 
     { 
       useFirebase && (
-      <WithHelpText
-        notched
-        shrink
-        label="format"
-        className="formatTab"
-      >
-        <Grid component="label" container alignItems="center" spacing={1}>
-          <Grid item>form</Grid>
-          <Grid item>
-            <Switch
-              data-testid="use form"
-              checked={useTextBox}
-              onChange={e => {
-                setUseTextBox(e.target.checked)
-              }}
-              name="use form"
-              color="primary"
-            />
-          </Grid>
-          <Grid item>text box</Grid>
-        </Grid>
-      </WithHelpText>
+        <>
+          <WithHelpText
+            notched
+            shrink
+            label="Payload Format"
+            className="formatTab"
+          >
+            <Grid component="label" container alignItems="center" spacing={1}>
+              <Grid item>Form</Grid>
+              <Grid item>
+                <Switch
+                  data-testid="use form"
+                  checked={useTextBox}
+                  onChange={e => {
+                    setUseTextBox(e.target.checked)
+                  }}
+                  name="use form"
+                  color="primary"
+                />
+              </Grid>
+              <Grid item>Text Box</Grid>
+            </Grid>
+          </WithHelpText>
+
+          <br/>
+        </>
       )
     }
 
     { useTextBox && 
       <div>
         <section className={formClasses.form}>
-          <br/>
-
           <LinkedTextField
             required
             href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference#api_secret"
@@ -336,7 +340,6 @@ const EventBuilder: React.FC = () => {
           linkTitle="Enter payload here"
           value={Object.keys(payloadObj).length > 0 ? payloadObj : inputPayload}
           label={Label.Payload}
-          helperText="Payload"
           onChange={(input) => {
               setInputPayload(input)
               formatPayload()
@@ -344,21 +347,30 @@ const EventBuilder: React.FC = () => {
           }
         />
 
-        <h3
-          style={{color: 'red'}}
-        >
-          {payloadErrors}
-        </h3>
-
         <br/>
 
         <br/>
 
-        <Button
+        <PlainButton small
           onClick={formatPayload}
         >
           format payload
-        </Button>
+        </PlainButton>
+
+        { payloadErrors && (
+            <TooltipIconButton
+              tooltip={
+                <React.Fragment>
+                  <Typography color="inherit">{payloadErrors}</Typography>
+                </React.Fragment>
+              }
+              placement={'top'}
+            >
+              <ErrorIcon
+                style={{color: 'red'}}
+              /> 
+            </TooltipIconButton>
+        )}
       </div>
     }
 

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -292,7 +292,7 @@ const EventBuilder: React.FC = () => {
           label={Label.Payload}
           helperText="Payload"
           onChange={(input) => {
-              setPayloadObj({})
+              setPayloadObj(input)
               setInputPayload(input)
             }
           }

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -40,6 +40,7 @@ import useUserProperties from "./useUserProperties"
 import Items from "./Items"
 import ValidateEvent from "./ValidateEvent"
 import { Button } from "@material-ui/core"
+import { useEffect } from "react"
 
 export enum Label {
   APISecret = "api_secret",
@@ -129,6 +130,10 @@ export const ShowAdvancedCtx = React.createContext(false)
 export const UseFirebaseCtx = React.createContext(false)
 
 const EventBuilder: React.FC = () => {
+  useEffect(() => {
+    formatPayload()
+  }, [])
+
   const formClasses = useFormStyles()
   const classes = useStyles()
   const [showAdvanced, setShowAdvanced] = React.useState(false)
@@ -140,6 +145,7 @@ const EventBuilder: React.FC = () => {
     setUserPropertyName,
     setUserPopertyValue,
   } = useUserProperties()
+
   const {
     parameters,
     items,
@@ -197,6 +203,7 @@ const EventBuilder: React.FC = () => {
 
   const formatPayload = () => {
     console.log('formatting')
+
     try {
       if (inputPayload) {
         let payload = JSON.parse(inputPayload) as object
@@ -209,6 +216,7 @@ const EventBuilder: React.FC = () => {
       }
 
     } catch (err: any) {
+      console.log('errors')
       setPayloadErrors(err.message)
       setPayloadObj({})
     }
@@ -284,6 +292,44 @@ const EventBuilder: React.FC = () => {
 
     { useTextBox && 
       <div>
+        <section className={formClasses.form}>
+          <br/>
+
+          <LinkedTextField
+            required
+            href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference#api_secret"
+            linkTitle="See api_secret on devsite."
+            value={api_secret || ""}
+            label={Label.APISecret}
+            id={Label.APISecret}
+            helperText="The API secret for the property to send the event to."
+            onChange={setAPISecret}
+          />
+          {useFirebase ? (
+              <LinkedTextField
+                required
+                href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#firebase_app_id"
+                linkTitle="See firebase_app_id on devsite."
+                value={firebase_app_id || ""}
+                label={Label.FirebaseAppID}
+                id={Label.FirebaseAppID}
+                helperText="The identifier for your firebase app."
+                onChange={setFirebaseAppId}
+              />
+          ) : (
+              <LinkedTextField
+                required
+                href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#measurement_id"
+                linkTitle="See measurement_id on devsite."
+                value={measurement_id || ""}
+                label={Label.MeasurementID}
+                id={Label.MeasurementID}
+                helperText="The identifier for your data stream."
+                onChange={setMeasurementId}
+              />
+          )}
+        </section>
+
         <TextBox
           required
           href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference#api_secret"
@@ -292,14 +338,22 @@ const EventBuilder: React.FC = () => {
           label={Label.Payload}
           helperText="Payload"
           onChange={(input) => {
-              setPayloadObj(input)
               setInputPayload(input)
+              formatPayload()
             }
           }
         />
-        {payloadErrors}
+
+        <h3
+          style={{color: 'red'}}
+        >
+          {payloadErrors}
+        </h3>
+
         <br/>
+
         <br/>
+
         <Button
           onClick={formatPayload}
         >
@@ -307,264 +361,265 @@ const EventBuilder: React.FC = () => {
         </Button>
       </div>
     }
-      { !useTextBox && 
-      <div>
-      <section className={formClasses.form}>
-        <LinkedTextField
-          required
-          href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference#api_secret"
-          linkTitle="See api_secret on devsite."
-          value={api_secret || ""}
-          label={Label.APISecret}
-          id={Label.APISecret}
-          helperText="The API secret for the property to send the event to."
-          onChange={setAPISecret}
-        />
-        {useFirebase ? (
-          <>
-            <LinkedTextField
-              required
-              href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#firebase_app_id"
-              linkTitle="See firebase_app_id on devsite."
-              value={firebase_app_id || ""}
-              label={Label.FirebaseAppID}
-              id={Label.FirebaseAppID}
-              helperText="The identifier for your firebase app."
-              onChange={setFirebaseAppId}
-            />
-            <LinkedTextField
-              required
-              href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#app_instance_id"
-              linkTitle="See app_instance_id on devsite."
-              value={app_instance_id || ""}
-              label={Label.AppInstanceID}
-              id={Label.AppInstanceID}
-              helperText="The unique identifier for a specific Firebase installation."
-              onChange={setAppInstanceId}
-            />
-          </>
-        ) : (
-          <>
-            <LinkedTextField
-              required
-              href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#measurement_id"
-              linkTitle="See measurement_id on devsite."
-              value={measurement_id || ""}
-              label={Label.MeasurementID}
-              id={Label.MeasurementID}
-              helperText="The identifier for your data stream."
-              onChange={setMeasurementId}
-            />
-            <LinkedTextField
-              required
-              href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#client_id"
-              linkTitle="See client_id on devsite."
-              value={client_id || ""}
-              label={Label.ClientID}
-              id={Label.ClientID}
-              helperText="The unique identifier for an instance of a web client."
-              onChange={setClientId}
-            />
-          </>
-        )}
-        <LinkedTextField
-          href={`https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=${
-            useFirebase ? "firebase" : "gtag"
-          }#user_id`}
-          linkTitle="See user_id on devsite."
-          value={user_id || ""}
-          label={Label.UserId}
-          id={Label.UserId}
-          helperText="The unique identifier for a given user."
-          onChange={setUserId}
-        />
 
-        <Autocomplete<Category, false, true, true>
-          data-testid={Label.EventCategory}
-          fullWidth
-          disableClearable
-          autoComplete
-          autoHighlight
-          autoSelect
-          options={Object.values(Category)}
-          getOptionLabel={category => category}
-          value={category}
-          onChange={(_event, value) => {
-            setCategory(value as Category)
-            const events = eventsForCategory(value as Category)
-            if (events.length > 0) {
-              setType(events[0].type)
-            }
-          }}
-          renderInput={params => (
-            <TextField
-              {...params}
-              label={Label.EventCategory}
-              id={Label.EventCategory}
-              size="small"
-              variant="outlined"
-              helperText="The category for the event"
-            />
-          )}
-        />
-        {type === EventType.CustomEvent ? (
-          <TextField
-            fullWidth
-            variant="outlined"
-            size="small"
-            label={Label.EventName}
-            id={Label.EventName}
-            value={eventName}
-            helperText="The name of the event"
-            onChange={e => {
-              setEventName(e.target.value)
-            }}
+    { !useTextBox && 
+      <div>
+        <section className={formClasses.form}>
+          <LinkedTextField
+            required
+            href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference#api_secret"
+            linkTitle="See api_secret on devsite."
+            value={api_secret || ""}
+            label={Label.APISecret}
+            id={Label.APISecret}
+            helperText="The API secret for the property to send the event to."
+            onChange={setAPISecret}
           />
-        ) : (
-          <Autocomplete<EventType, false, true, true>
-            data-testid={Label.EventName}
+          {useFirebase ? (
+            <>
+              <LinkedTextField
+                required
+                href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#firebase_app_id"
+                linkTitle="See firebase_app_id on devsite."
+                value={firebase_app_id || ""}
+                label={Label.FirebaseAppID}
+                id={Label.FirebaseAppID}
+                helperText="The identifier for your firebase app."
+                onChange={setFirebaseAppId}
+              />
+              <LinkedTextField
+                required
+                href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#app_instance_id"
+                linkTitle="See app_instance_id on devsite."
+                value={app_instance_id || ""}
+                label={Label.AppInstanceID}
+                id={Label.AppInstanceID}
+                helperText="The unique identifier for a specific Firebase installation."
+                onChange={setAppInstanceId}
+              />
+            </>
+          ) : (
+            <>
+              <LinkedTextField
+                required
+                href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#measurement_id"
+                linkTitle="See measurement_id on devsite."
+                value={measurement_id || ""}
+                label={Label.MeasurementID}
+                id={Label.MeasurementID}
+                helperText="The identifier for your data stream."
+                onChange={setMeasurementId}
+              />
+              <LinkedTextField
+                required
+                href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#client_id"
+                linkTitle="See client_id on devsite."
+                value={client_id || ""}
+                label={Label.ClientID}
+                id={Label.ClientID}
+                helperText="The unique identifier for an instance of a web client."
+                onChange={setClientId}
+              />
+            </>
+          )}
+          <LinkedTextField
+            href={`https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=${
+              useFirebase ? "firebase" : "gtag"
+            }#user_id`}
+            linkTitle="See user_id on devsite."
+            value={user_id || ""}
+            label={Label.UserId}
+            id={Label.UserId}
+            helperText="The unique identifier for a given user."
+            onChange={setUserId}
+          />
+
+          <Autocomplete<Category, false, true, true>
+            data-testid={Label.EventCategory}
             fullWidth
             disableClearable
             autoComplete
             autoHighlight
             autoSelect
-            options={eventsForCategory(category).map(e => e.type)}
-            getOptionLabel={eventType => eventType}
-            value={type}
+            options={Object.values(Category)}
+            getOptionLabel={category => category}
+            value={category}
             onChange={(_event, value) => {
-              setType(value as EventType)
+              setCategory(value as Category)
+              const events = eventsForCategory(value as Category)
+              if (events.length > 0) {
+                setType(events[0].type)
+              }
             }}
             renderInput={params => (
               <TextField
                 {...params}
-                label={Label.EventName}
-                id={Label.EventName}
+                label={Label.EventCategory}
+                id={Label.EventCategory}
                 size="small"
                 variant="outlined"
-                helperText={
-                  <>
-                    The name of the event. See{" "}
-                    <ExternalLink
-                      href={`https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#${type}`}
-                    >
-                      {type}
-                    </ExternalLink>{" "}
-                    on devsite.
-                  </>
-                }
+                helperText="The category for the event"
               />
             )}
           />
-        )}
-        <LinkedTextField
-          label={Label.TimestampMicros}
-          id={Label.TimestampMicros}
-          linkTitle="See timestamp_micros on devsite."
-          href={`https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=${
-            useFirebase ? "firebase" : "gtag"
-          }#timestamp_micros`}
-          value={timestamp_micros || ""}
-          onChange={setTimestampMicros}
-          helperText="The timestamp of the event."
-          extraAction={
-            <Tooltip title="Set to now.">
-              <IconButton
-                size="small"
-                onClick={() => {
-                  setTimestampMicros((new Date().getTime() * 1000).toString())
-                }}
-              >
-                <Refresh />
-              </IconButton>
-            </Tooltip>
-          }
-        />
-
-        <WithHelpText
-          helpText={
-            <>
-              Check to indicate events should not be used for personalized ads.
-              See{" "}
-              <ExternalLink
-                href={`https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=${
-                  useFirebase ? "firebase" : "gtag"
-                }#non_personalized_ads`}
-              >
-                non_personalized_ads
-              </ExternalLink>{" "}
-              on devsite.
-            </>
-          }
-        >
-          <LabeledCheckbox
-            checked={non_personalized_ads}
-            setChecked={setNonPersonalizedAds}
-            id={Label.NonPersonalizedAds}
-          >
-            {Label.NonPersonalizedAds}
-          </LabeledCheckbox>
-        </WithHelpText>
-      </section>
-
-      <Typography variant="h4">Event details</Typography>
-      <Typography>
-        Finally, specify the parameters to send with the event. By default, only
-        recommended parameters for the event will appear here. Check "show
-        advanced options" to add custom parameters or user properties.
-      </Typography>
-      <LabeledCheckbox checked={showAdvanced} onChange={setShowAdvanced}>
-        show advanced options
-      </LabeledCheckbox>
-
-      <section className={formClasses.form}>
-        <ShowAdvancedCtx.Provider
-          value={showAdvanced || type === EventType.CustomEvent}
-        >
-          <Typography variant="h5">Parameters</Typography>
-          <Parameters
-            removeParam={removeParam}
-            parameters={parameters}
-            addStringParam={addStringParam}
-            addNumberParam={addNumberParam}
-            setParamName={setParamName}
-            setParamValue={setParamValue}
-            addItemsParam={items === undefined ? addItemsParam : undefined}
+          {type === EventType.CustomEvent ? (
+            <TextField
+              fullWidth
+              variant="outlined"
+              size="small"
+              label={Label.EventName}
+              id={Label.EventName}
+              value={eventName}
+              helperText="The name of the event"
+              onChange={e => {
+                setEventName(e.target.value)
+              }}
+            />
+          ) : (
+            <Autocomplete<EventType, false, true, true>
+              data-testid={Label.EventName}
+              fullWidth
+              disableClearable
+              autoComplete
+              autoHighlight
+              autoSelect
+              options={eventsForCategory(category).map(e => e.type)}
+              getOptionLabel={eventType => eventType}
+              value={type}
+              onChange={(_event, value) => {
+                setType(value as EventType)
+              }}
+              renderInput={params => (
+                <TextField
+                  {...params}
+                  label={Label.EventName}
+                  id={Label.EventName}
+                  size="small"
+                  variant="outlined"
+                  helperText={
+                    <>
+                      The name of the event. See{" "}
+                      <ExternalLink
+                        href={`https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#${type}`}
+                      >
+                        {type}
+                      </ExternalLink>{" "}
+                      on devsite.
+                    </>
+                  }
+                />
+              )}
+            />
+          )}
+          <LinkedTextField
+            label={Label.TimestampMicros}
+            id={Label.TimestampMicros}
+            linkTitle="See timestamp_micros on devsite."
+            href={`https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=${
+              useFirebase ? "firebase" : "gtag"
+            }#timestamp_micros`}
+            value={timestamp_micros || ""}
+            onChange={setTimestampMicros}
+            helperText="The timestamp of the event."
+            extraAction={
+              <Tooltip title="Set to now.">
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    setTimestampMicros((new Date().getTime() * 1000).toString())
+                  }}
+                >
+                  <Refresh />
+                </IconButton>
+              </Tooltip>
+            }
           />
-          {items !== undefined && (
-            <>
-              <Typography variant="h5">Items</Typography>
-              <Items
-                items={items}
-                addItem={addItem}
-                removeItem={removeItem}
-                removeItemParam={removeItemParam}
-                addItemNumberParam={addItemNumberParam}
-                addItemStringParam={addItemStringParam}
-                setItemParamName={setItemParamName}
-                setItemParamValue={setItemParamValue}
-                removeItems={removeItems}
-              />
-            </>
-          )}
 
-          {(showAdvanced ||
-            (userProperties !== undefined && userProperties.length !== 0)) && (
-            <>
-              <Typography variant="h5">User properties</Typography>
-              <Parameters
-                removeParam={removeUserProperty}
-                parameters={userProperties}
-                addStringParam={addStringUserProperty}
-                addNumberParam={addNumberUserProperty}
-                setParamName={setUserPropertyName}
-                setParamValue={setUserPopertyValue}
-              />
-            </>
-          )}
-        </ShowAdvancedCtx.Provider>
-      </section>
+          <WithHelpText
+            helpText={
+              <>
+                Check to indicate events should not be used for personalized ads.
+                See{" "}
+                <ExternalLink
+                  href={`https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=${
+                    useFirebase ? "firebase" : "gtag"
+                  }#non_personalized_ads`}
+                >
+                  non_personalized_ads
+                </ExternalLink>{" "}
+                on devsite.
+              </>
+            }
+          >
+            <LabeledCheckbox
+              checked={non_personalized_ads}
+              setChecked={setNonPersonalizedAds}
+              id={Label.NonPersonalizedAds}
+            >
+              {Label.NonPersonalizedAds}
+            </LabeledCheckbox>
+          </WithHelpText>
+        </section>
+
+        <Typography variant="h4">Event details</Typography>
+        <Typography>
+          Finally, specify the parameters to send with the event. By default, only
+          recommended parameters for the event will appear here. Check "show
+          advanced options" to add custom parameters or user properties.
+        </Typography>
+        <LabeledCheckbox checked={showAdvanced} onChange={setShowAdvanced}>
+          show advanced options
+        </LabeledCheckbox>
+
+        <section className={formClasses.form}>
+          <ShowAdvancedCtx.Provider
+            value={showAdvanced || type === EventType.CustomEvent}
+          >
+            <Typography variant="h5">Parameters</Typography>
+            <Parameters
+              removeParam={removeParam}
+              parameters={parameters}
+              addStringParam={addStringParam}
+              addNumberParam={addNumberParam}
+              setParamName={setParamName}
+              setParamValue={setParamValue}
+              addItemsParam={items === undefined ? addItemsParam : undefined}
+            />
+            {items !== undefined && (
+              <>
+                <Typography variant="h5">Items</Typography>
+                <Items
+                  items={items}
+                  addItem={addItem}
+                  removeItem={removeItem}
+                  removeItemParam={removeItemParam}
+                  addItemNumberParam={addItemNumberParam}
+                  addItemStringParam={addItemStringParam}
+                  setItemParamName={setItemParamName}
+                  setItemParamValue={setItemParamValue}
+                  removeItems={removeItems}
+                />
+              </>
+            )}
+
+            {(showAdvanced ||
+              (userProperties !== undefined && userProperties.length !== 0)) && (
+              <>
+                <Typography variant="h5">User properties</Typography>
+                <Parameters
+                  removeParam={removeUserProperty}
+                  parameters={userProperties}
+                  addStringParam={addStringUserProperty}
+                  addNumberParam={addNumberUserProperty}
+                  setParamName={setUserPropertyName}
+                  setParamValue={setUserPopertyValue}
+                />
+              </>
+            )}
+          </ShowAdvancedCtx.Provider>
+        </section>
       </div>
-      }
+    }
 
       <Typography variant="h3" className={classes.validateHeading}>
         Validate & Send event
@@ -596,6 +651,7 @@ const EventBuilder: React.FC = () => {
             app_instance_id={app_instance_id || ""}
             firebase_app_id={firebase_app_id || ""}
             formatPayload={formatPayload}
+            payloadErrors={payloadErrors}
           />
         </EventCtx.Provider>
       </UseFirebaseCtx.Provider>

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -122,7 +122,7 @@ export const EventCtx = React.createContext<
       instanceId: InstanceId
       api_secret: string
       useTextBox: boolean
-      payloadObj: object
+      payloadObj: any
     }
   | undefined
 >(undefined)

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -271,11 +271,11 @@ const EventBuilder: React.FC = () => {
           <WithHelpText
             notched
             shrink
-            label="Validation Method"
+            label="validation method"
             className="formatTab"
           >
             <Grid component="label" container alignItems="center" spacing={1}>
-              <Grid item>Form</Grid>
+              <Grid item>form</Grid>
               <Grid item>
                 <Switch
                   data-testid="use form"
@@ -287,7 +287,7 @@ const EventBuilder: React.FC = () => {
                   color="primary"
                 />
               </Grid>
-              <Grid item>Text Box</Grid>
+              <Grid item>text box</Grid>
             </Grid>
           </WithHelpText>
 

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -41,6 +41,7 @@ import Items from "./Items"
 import ValidateEvent from "./ValidateEvent"
 import { Button } from "@material-ui/core"
 import { useEffect } from "react"
+import { RequestStatus } from "@/types"
 
 export enum Label {
   APISecret = "api_secret",
@@ -130,10 +131,6 @@ export const ShowAdvancedCtx = React.createContext(false)
 export const UseFirebaseCtx = React.createContext(false)
 
 const EventBuilder: React.FC = () => {
-  useEffect(() => {
-    formatPayload()
-  }, [])
-
   const formClasses = useFormStyles()
   const classes = useStyles()
   const [showAdvanced, setShowAdvanced] = React.useState(false)
@@ -201,6 +198,14 @@ const EventBuilder: React.FC = () => {
     setNonPersonalizedAds,
   } = useInputs(categories)
 
+  useEffect(() => {
+    formatPayload()
+  }, [])
+
+  useEffect(() => {
+    formatPayload()
+  }, [inputPayload])
+
   const formatPayload = () => {
     console.log('formatting')
 
@@ -216,7 +221,6 @@ const EventBuilder: React.FC = () => {
       }
 
     } catch (err: any) {
-      console.log('errors')
       setPayloadErrors(err.message)
       setPayloadObj({})
     }
@@ -652,6 +656,7 @@ const EventBuilder: React.FC = () => {
             firebase_app_id={firebase_app_id || ""}
             formatPayload={formatPayload}
             payloadErrors={payloadErrors}
+            useTextBox={useTextBox}
           />
         </EventCtx.Provider>
       </UseFirebaseCtx.Provider>

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -121,7 +121,7 @@ export const EventCtx = React.createContext<
       instanceId: InstanceId
       api_secret: string
       useTextBox: boolean
-      payloadObj: object
+      // payloadObj: object
     }
   | undefined
 >(undefined)
@@ -196,6 +196,7 @@ const EventBuilder: React.FC = () => {
   } = useInputs(categories)
 
   const formatPayload = () => {
+    console.log('formatting')
     try {
       if (inputPayload) {
         let payload = JSON.parse(inputPayload) as object
@@ -584,7 +585,6 @@ const EventBuilder: React.FC = () => {
             useTextBox,
             instanceId: useFirebase ? { firebase_app_id } : { measurement_id },
             api_secret: api_secret!,
-            payloadObj,
           }}
         >
           <ValidateEvent
@@ -594,7 +594,7 @@ const EventBuilder: React.FC = () => {
             measurement_id={measurement_id || ""}
             app_instance_id={app_instance_id || ""}
             firebase_app_id={firebase_app_id || ""}
-            payloadObj={payloadObj}
+            formatPayload={formatPayload}
           />
         </EventCtx.Provider>
       </UseFirebaseCtx.Provider>

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -41,7 +41,6 @@ import Items from "./Items"
 import ValidateEvent from "./ValidateEvent"
 import { Button } from "@material-ui/core"
 import { useEffect } from "react"
-import { RequestStatus } from "@/types"
 
 export enum Label {
   APISecret = "api_secret",
@@ -263,7 +262,6 @@ const EventBuilder: React.FC = () => {
       <Typography>
         After choosing a client, fill out the inputs below.
       </Typography>
-
 
     { 
       useFirebase && (

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -271,7 +271,7 @@ const EventBuilder: React.FC = () => {
           <WithHelpText
             notched
             shrink
-            label="Payload Format"
+            label="Validation Method"
             className="formatTab"
           >
             <Grid component="label" container alignItems="center" spacing={1}>

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -207,8 +207,6 @@ const EventBuilder: React.FC = () => {
   }, [inputPayload])
 
   const formatPayload = () => {
-    console.log('formatting')
-
     try {
       if (inputPayload) {
         let payload = JSON.parse(inputPayload) as object

--- a/src/components/ga4/EventBuilder/index.tsx
+++ b/src/components/ga4/EventBuilder/index.tsx
@@ -121,7 +121,7 @@ export const EventCtx = React.createContext<
       instanceId: InstanceId
       api_secret: string
       useTextBox: boolean
-      // payloadObj: object
+      payloadObj: object
     }
   | undefined
 >(undefined)
@@ -583,6 +583,7 @@ const EventBuilder: React.FC = () => {
             timestamp_micros,
             non_personalized_ads,
             useTextBox,
+            payloadObj,
             instanceId: useFirebase ? { firebase_app_id } : { measurement_id },
             api_secret: api_secret!,
           }}

--- a/src/components/ga4/EventBuilder/types.ts
+++ b/src/components/ga4/EventBuilder/types.ts
@@ -101,7 +101,9 @@ export enum UrlParam {
   AppInstanceId = "o",
   Version = "p",
   UseTextBox = "q",
-  Payload = "r"
+  Payload = "r",
+  PayloadObj = "s",
+  PayloadError = "t"
 }
 
 export enum ValidationStatus {

--- a/src/components/ga4/EventBuilder/types.ts
+++ b/src/components/ga4/EventBuilder/types.ts
@@ -100,6 +100,8 @@ export enum UrlParam {
   ClientId = "n",
   AppInstanceId = "o",
   Version = "p",
+  UseTextBox = "q",
+  Payload = "r"
 }
 
 export enum ValidationStatus {

--- a/src/components/ga4/EventBuilder/useEvent.ts
+++ b/src/components/ga4/EventBuilder/useEvent.ts
@@ -117,6 +117,30 @@ export const ParametersParam: QueryParamConfig<
   },
 }
 
+// move this to the index.tsx file for now
+// create a new state for payloadObj and save this to that
+export const formatPayload = (payload) => {
+  console.log('formatPayload', payload)
+  let formattingErrorMessage = '';
+
+  // try {
+  //   const payloadObj: object = JSON.parse(payload) as object;
+  //   if (true) {
+  //     const payloadStringFormatted: string =
+  //         JSON.stringify(payloadObj, null, '\t');
+  //     // this.eventEntryForm.patchValue({'payload': payloadStringFormatted});
+  //   }
+  //   return true;
+  // } catch (ex: unknown) {
+  //   if (ex instanceof Error) {
+  //     if (true) {
+  //     // this.payloadAsJSON = {};
+  //     formattingErrorMessage = ex.message;
+  //   }
+  // }
+  // return false;
+}
+
 const useEvent = (initial?: EventType) => {
   const [typeString, setTypeLocal] = useHydratedPersistantString(
     StorageKey.ga4EventBuilderLastEventType,

--- a/src/components/ga4/EventBuilder/useEvent.ts
+++ b/src/components/ga4/EventBuilder/useEvent.ts
@@ -117,30 +117,6 @@ export const ParametersParam: QueryParamConfig<
   },
 }
 
-// move this to the index.tsx file for now
-// create a new state for payloadObj and save this to that
-export const formatPayload = (payload) => {
-  console.log('formatPayload', payload)
-  let formattingErrorMessage = '';
-
-  // try {
-  //   const payloadObj: object = JSON.parse(payload) as object;
-  //   if (true) {
-  //     const payloadStringFormatted: string =
-  //         JSON.stringify(payloadObj, null, '\t');
-  //     // this.eventEntryForm.patchValue({'payload': payloadStringFormatted});
-  //   }
-  //   return true;
-  // } catch (ex: unknown) {
-  //   if (ex instanceof Error) {
-  //     if (true) {
-  //     // this.payloadAsJSON = {};
-  //     formattingErrorMessage = ex.message;
-  //   }
-  // }
-  // return false;
-}
-
 const useEvent = (initial?: EventType) => {
   const [typeString, setTypeLocal] = useHydratedPersistantString(
     StorageKey.ga4EventBuilderLastEventType,

--- a/src/components/ga4/EventBuilder/useInputs.ts
+++ b/src/components/ga4/EventBuilder/useInputs.ts
@@ -4,7 +4,7 @@ import {
   useHydratedPersistantString,
 } from "@/hooks/useHydrated"
 import { useState } from "react"
-import { Category, UrlParam, Parameter } from "./types"
+import { Category, UrlParam } from "./types"
 
 const useInputs = (categories: Category[]) => {
   const [useFirebase, setUseFirebase] = useHydratedPersistantBoolean(

--- a/src/components/ga4/EventBuilder/useInputs.ts
+++ b/src/components/ga4/EventBuilder/useInputs.ts
@@ -4,7 +4,7 @@ import {
   useHydratedPersistantString,
 } from "@/hooks/useHydrated"
 import { useState } from "react"
-import { Category, UrlParam } from "./types"
+import { Category, UrlParam, Parameter } from "./types"
 
 const useInputs = (categories: Category[]) => {
   const [useFirebase, setUseFirebase] = useHydratedPersistantBoolean(
@@ -23,6 +23,9 @@ const useInputs = (categories: Category[]) => {
     StorageKey.ga4EventBuilderPayload,
     UrlParam.APISecret
   )
+
+
+  const [payloadObj, setPayloadObj] = useState({})
 
   const [api_secret, setAPISecret] = useHydratedPersistantString(
     StorageKey.eventBuilderApiSecret,
@@ -54,6 +57,11 @@ const useInputs = (categories: Category[]) => {
     UrlParam.UserId
   )
 
+  const [payloadErrors, setPayloadErrors] = useHydratedPersistantString(
+    StorageKey.ga4EventBuilderPayloadError,
+    UrlParam.PayloadError
+  )
+
   const [category, setCategory] = useState(categories[0])
 
   const [
@@ -77,6 +85,10 @@ const useInputs = (categories: Category[]) => {
     setUseTextBox,
     inputPayload,
     setInputPayload,
+    payloadObj,
+    setPayloadObj,
+    payloadErrors,
+    setPayloadErrors,
     category,
     setCategory,
     api_secret,

--- a/src/components/ga4/EventBuilder/useInputs.ts
+++ b/src/components/ga4/EventBuilder/useInputs.ts
@@ -13,6 +13,17 @@ const useInputs = (categories: Category[]) => {
     true
   )
 
+  const [useTextBox, setUseTextBox] = useHydratedPersistantBoolean(
+    StorageKey.eventBuilderUseFirebase,
+    UrlParam.UseTextBox,
+    false
+  )
+
+  const [inputPayload, setInputPayload] = useHydratedPersistantString(
+    StorageKey.ga4EventBuilderPayload,
+    UrlParam.APISecret
+  )
+
   const [api_secret, setAPISecret] = useHydratedPersistantString(
     StorageKey.eventBuilderApiSecret,
     UrlParam.APISecret
@@ -62,6 +73,10 @@ const useInputs = (categories: Category[]) => {
   return {
     useFirebase,
     setUseFirebase,
+    useTextBox,
+    setUseTextBox,
+    inputPayload,
+    setInputPayload,
     category,
     setCategory,
     api_secret,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -248,6 +248,7 @@ export enum StorageKey {
   ga4EventBuilderItems = "ga4/event-builder/items",
   ga4EventBuilderEventName = "ga4/event-builder/event-name",
   ga4EventBuilderUserProperties = "ga4/event-builder/user-properties",
+  ga4EventBuilderPayload = "ga4/event-builder/payload",
 }
 
 export const EventAction = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -249,6 +249,8 @@ export enum StorageKey {
   ga4EventBuilderEventName = "ga4/event-builder/event-name",
   ga4EventBuilderUserProperties = "ga4/event-builder/user-properties",
   ga4EventBuilderPayload = "ga4/event-builder/payload",
+  ga4EventBuilderPayloadObj = "ga4/event-builder/payload-obj",
+  ga4EventBuilderPayloadError = "ga4/event-builder/payload-error",
 }
 
 export const EventAction = {


### PR DESCRIPTION
This PR adds a textbox to the event builder that allows advertisers to paste their JSON payload directly into the event builder and validate, rather than having to input each field individually through a form.

<img width="882" alt="Screenshot 2023-06-08 at 2 52 45 PM" src="https://github.com/googleanalytics/ga-dev-tools/assets/39474777/90f0b63d-1184-43cc-a513-2a99a3086baa">
