### PR TITLE
Move timestamp_micros into the events entries (#1751)

### DIFF
--- a/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/usePayload.ts
@@ -106,11 +106,14 @@ const usePayload = (): {} => {
   let payload = useMemo(() => {
     return {
       ...removeUndefined(clientIds),
-      ...removeUndefined({ timestamp_micros }),
       ...removeUndefined({ non_personalized_ads }),
       ...removeUndefined(removeEmptyObject({ user_properties })),
       events: [
-        { name: eventName, ...(parameters.length > 0 ? { params } : {}) },
+        {
+          name: eventName,
+          ...(parameters.length > 0 ? { params } : {}),
+          ...removeUndefined({ timestamp_micros })
+        },
       ],
     }
   }, [


### PR DESCRIPTION
As discussed on the linked issue, the field doesn't work in the current location, it needs to be on the individual events.