### PR TITLE
fix(EventBuilder): query parameter syntax issue

### DIFF
--- a/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
+++ b/src/components/ga4/EventBuilder/ValidateEvent/useValidateEvent.ts
@@ -55,9 +55,9 @@ const sendHit = async (
   instanceId: InstanceId,
   api_secret: string
 ): Promise<void> => {
-  const url = `https://www.google-analytics.com/mp/collect?${instanceQueryParamFor(
+  const url = `https://www.google-analytics.com/mp/collect?api_secret=${api_secret}${instanceQueryParamFor(
     instanceId
-  )}&api_secret=${api_secret}`
+  )}`
   const body = Object.assign({}, payload, {
     validationBehavior: "ENFORCE_RECOMMENDATIONS",
   })


### PR DESCRIPTION
Fix format of query parameters when sending events using Event Builder. 

- Requests were being sent with additional ampersand, i.e., `?&measurement_id=..`
- This happens when sending the event to Google Analytics, not when using validation endpoint.