### PR TITLE
fix(EventBuilder): fix useTextBox, useFirebase persistence bug

### DIFF
--- a/src/components/ga4/EventBuilder/useInputs.ts
+++ b/src/components/ga4/EventBuilder/useInputs.ts
@@ -14,7 +14,7 @@ const useInputs = (categories: Category[]) => {
   )
 
   const [useTextBox, setUseTextBox] = useHydratedPersistantBoolean(
-    StorageKey.eventBuilderUseFirebase,
+    StorageKey.eventBuilderUseTextBox,
     UrlParam.UseTextBox,
     false
   )

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -243,6 +243,7 @@ export enum StorageKey {
   eventBuilderTimestampMicros = "ga4/event-builder/timestamp-micros",
   eventBuilderNonPersonalizedAds = "ga4/event-builder/non-personalized-ads",
   eventBuilderUseFirebase = "ga4/event-builder/use-firebase",
+  eventBuilderUseTextBox = "ga4/event-builder/use-text-box",
   ga4EventBuilderEvents = "ga4/event-builder/events",
   ga4EventBuilderLastEventType = "ga4/event-builder/last-event-type",
   ga4EventBuilderParameters = "ga4/event-builder/parameters",


### PR DESCRIPTION
Fix minor bug when persisting useTextBox field which was leading to inconsistent UI behavior.

- `useTextBox` was writing to the same key storage value as `useFirebase`, which was causing a key collision and resulting in the inputs overwriting each other
- The purpose of `useHydratedPersistantBoolean` is to save state to local storage so it can be remembered across page loads
- When the page is reloaded, both states will be initialized from the last-written value and cause inconsistent UI behavior
