### PR TITLE
fix(staging): remove google redirect for staging environment

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -124,7 +124,7 @@ const Template: React.FC<PropsWithChildren<LayoutProps & TemplateProps>> = ({
   useEffect(() => {
     //const timeout = setTimeout(() => {
     // Redirect to the new domain while preserving the path.
-    if( window.location.hostname.indexOf('web.app') !== -1 ) {
+    if( window.location.hostname.indexOf('web.app') !== -1 && !window.location.hostname.includes('staging')) {
       const newHostname = window.location.hostname.replace('web.app', 'google');
       const newLocation =  window.location.href.replace( window.location.hostname, newHostname );
       window.location.replace(newLocation);


### PR DESCRIPTION
When trying to access the new staging environment, a redirect is happening replacing web.app with google which is not a valid hostname. For now we are removing this redirect so the staging environment can be accessed.

`https://ga-demos-and-tools-staging.web.app/`
`https://ga-demos-and-tools-staging.google/`