### PR TITLE
fix(Auth): simplify logout call

### DIFF
--- a/src/components/Layout/useLogin.ts
+++ b/src/components/Layout/useLogin.ts
@@ -36,15 +36,10 @@ const useLogin = (): Requestable<Successful, {}, InProgress, Failed> => {
   }, [tokenClient])
 
   const logout = useCallback(() => {
-    const token = gapi?.client.getToken()
-    if (token && google) {
-      google.accounts.oauth2.revoke(token.access_token, () => {
-        gapi?.client.setToken(null)
-        dispatch({ type: "setToken", token: undefined })
-        localStorage.removeItem("google_token")
-      })
-    }
-  }, [gapi, google, dispatch])
+    gapi?.client.setToken(null)
+    dispatch({ type: "setToken", token: undefined })
+    localStorage.removeItem("google_token")
+  }, [gapi, dispatch])
 
   useEffect(() => {
     if (gapiStatus === "cannot initialize") {


### PR DESCRIPTION
Simplify logout to clear the token from the app state and local storage instead of fully revoking permission that the user granted to the app. The access token will remain valid until it expires, but the user will be logged out in the UI. 

If the user signs in again before the token grant expires, they won't need to re-consent to permissions.


