### PR TITLE
chore(): resolve lint warnings 

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
 import { TextField } from "@mui/material"
-import clsx from "classnames"
 import { Dispatch } from "../types"
 import Autocomplete from "@mui/material/Autocomplete"
 

--- a/src/components/SelectMultiple.tsx
+++ b/src/components/SelectMultiple.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
 import { TextField } from "@mui/material"
-import clsx from "classnames"
 import { Dispatch } from "../types"
 import Autocomplete from "@mui/material/Autocomplete"
 

--- a/src/components/ga4/DimensionsMetricsExplorer/Field.tsx
+++ b/src/components/ga4/DimensionsMetricsExplorer/Field.tsx
@@ -7,7 +7,6 @@ import Typography from "@mui/material/Typography"
 
 import InlineCode from "@/components/InlineCode"
 import {CopyIconButton} from "@/components/CopyButton"
-import ExternalLink from "@/components/ExternalLink"
 import {Dimension, Metric} from "./useDimensionsAndMetrics"
 import {QueryParam} from "."
 import {AccountSummary, PropertySummary} from "@/types/ga4/StreamPicker"

--- a/src/components/ga4/EnhancedEcommerce/store-context.tsx
+++ b/src/components/ga4/EnhancedEcommerce/store-context.tsx
@@ -140,6 +140,8 @@ export const StoreProvider = (props: Props) => {
   const [cart, setCart] = React.useState(defaultValues.cart)
   const [lastCart, setLastCart] = React.useState(defaultValues.lastCart)
 
+  // TODO: Implement checkout flow, which will use setCheckoutState.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [checkoutState, setCheckoutState] = React.useState(defaultValues.checkoutState)
   const [events, setEvents] = React.useState(defaultValues.events)
 

--- a/src/components/ga4/EventBuilder/Parameters.tsx
+++ b/src/components/ga4/EventBuilder/Parameters.tsx
@@ -54,7 +54,7 @@ const Parameters: React.FC<Props> = ({
   removeParam,
   addItemsParam,
   removeItem,
-  allowTimestampOverride: allowTimestampOverride,
+  allowTimestampOverride,
 }) => {
   const showAdvanced = React.useContext(ShowAdvancedCtx)
 

--- a/src/pages/ga4/enhanced-ecommerce/products/{ProductsJson.title}.tsx
+++ b/src/pages/ga4/enhanced-ecommerce/products/{ProductsJson.title}.tsx
@@ -43,6 +43,8 @@ export default (props: PageProps<Props>) => {
         image,
     } = props.data.productsJson
     const initialVariant = 'M'
+    // TODO: Implement variant selection functionality, which will use setVariant.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [variant, setVariant] = React.useState(initialVariant)
     const productVariant = variant;
     const [quantity, setQuantity] = React.useState(1)


### PR DESCRIPTION
Address a number of linting issues, mainly of type `@typescript-eslint/no-unused-vars`.

For two instances `setVariant` and `setCheckoutState` (part of the Enhanced Ecommerce demo), the warning is occurring because the functionality is partially implemented. The features need to be revisited and implementation needs to be reevaluated more thoroughly. For now, this PR:

- Adds an `// eslint-disable-next-line @typescript-eslint/no-unused-vars` comment for each unused setter.
- Adds a `// TODO:` comment to each, explaining why the linter rule is being disabled and clarifying what feature needs to be implemented.

This will clean up the lint output (which has been flagging each PR) while preserving the existing code and context for future development.