### PR TITLE
feat(EventBuilder): allow in_app_purchase events for app streams

### DIFF
--- a/src/components/CampaignURLBuilder/index.spec.tsx
+++ b/src/components/CampaignURLBuilder/index.spec.tsx
@@ -22,6 +22,8 @@ import { GAVersion } from "../../constants"
 
 // Capture original error global so it's easier to replace after a mock.
 const originalError = console.error
+
+jest.setTimeout(10000)
 describe("for the Campaign URL Builder component", () => {
   beforeEach(() => {
     process.env.BITLY_CLIENT_ID = "bitly-client-id"

--- a/src/components/CampaignURLBuilder/index.spec.tsx
+++ b/src/components/CampaignURLBuilder/index.spec.tsx
@@ -23,6 +23,8 @@ import { GAVersion } from "../../constants"
 // Capture original error global so it's easier to replace after a mock.
 const originalError = console.error
 
+// Increase the timeout for this test suite. The userEvent.type calls can
+// be slow, and the default 5s timeout is not always enough.
 jest.setTimeout(10000)
 describe("for the Campaign URL Builder component", () => {
   beforeEach(() => {

--- a/src/components/ga4/EventBuilder/event.ts
+++ b/src/components/ga4/EventBuilder/event.ts
@@ -201,6 +201,22 @@ const generate_lead = eventFor(
   [stringParam("currency", "USD"), numberParam("value", 99.99)]
 )
 
+const in_app_purchase = eventFor(
+  EventType.InAppPurchase,
+  [Category.AllApps],
+  [
+    stringParam("currency", "USD"),
+    numberParam("value", 30.03),
+    numberParam("quantity", 3),
+    stringParam("product_id", "ABC123456789"),
+    stringParam("subscription", "true"),
+    stringParam("free_trial", "false"),
+    stringParam("price_is_discounted", "false"),
+  ],
+  undefined,
+  ["app"]
+)
+
 const join_group = eventFor(
   EventType.JoinGroup,
   [Category.AllApps],
@@ -548,6 +564,8 @@ export const suggestedEventFor = (eventType: EventType): Event2 => {
       return earn_virtual_currency
     case EventType.GenerateLead:
       return generate_lead
+    case EventType.InAppPurchase:
+      return in_app_purchase
     case EventType.JoinGroup:
       return join_group
     case EventType.LevelUp:

--- a/src/components/ga4/EventBuilder/index.spec.tsx
+++ b/src/components/ga4/EventBuilder/index.spec.tsx
@@ -23,6 +23,8 @@ import { Label } from "./types"
 import userEvent from "@testing-library/user-event"
 import { within } from "@testing-library/react"
 
+jest.setTimeout(10000)
+
 describe("Event Builder", () => {
   test("can render page without error", () => {
     const { wrapped } = withProviders(<Sut />)

--- a/src/components/ga4/EventBuilder/index.spec.tsx
+++ b/src/components/ga4/EventBuilder/index.spec.tsx
@@ -23,6 +23,8 @@ import { Label } from "./types"
 import userEvent from "@testing-library/user-event"
 import { within } from "@testing-library/react"
 
+// Increase the timeout for this test suite. The userEvent.type calls can
+// be slow, and the default 5s timeout is not always enough.
 jest.setTimeout(10000)
 
 describe("Event Builder", () => {

--- a/src/components/ga4/EventBuilder/types.ts
+++ b/src/components/ga4/EventBuilder/types.ts
@@ -60,6 +60,7 @@ export enum EventType {
   ViewItemList = "view_item_list",
   ViewPromotion = "view_promotion",
   ViewSearchResults = "view_search_results",
+  InAppPurchase = "in_app_purchase",
 }
 
 export interface NumberParameter {


### PR DESCRIPTION
Support in_app_purchase events for App streams in Measurement Protocol. Event only listed when client is toggled to firebase.

<details>
  <summary><h3>Screenshots</h3></summary>
  <img width="805" height="911" alt="image" src="https://github.com/user-attachments/assets/643b5426-4102-4d1d-89b2-d1b8e53a6a5e" />
<img width="785" height="915" alt="image" src="https://github.com/user-attachments/assets/e2860a2c-abc6-47bc-9e07-567030f013d0" />

</details>