### PR TITLE
chore(deps): bump node-fetch in /functions from ^2.6.7 to ^2.6.13

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -18,7 +18,7 @@
     "firebase-admin": "^8.10.0",
     "firebase-functions": "^3.13.2",
     "firebase-tools": "^9.10.0",
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^2.6.13"
   },
   "devDependencies": {
     "@types/cors": "^2.8.7",


### PR DESCRIPTION
## Summary

Bumps `node-fetch` in `functions/package.json` from `^2.6.7` to `^2.6.13`.

## Motivation

`node-fetch` 2.6.7 is affected by a known high-severity vulnerability:

| CVE | Severity | Description |
|-----|----------|-------------|
| [CVE-2022-0235](https://nvd.nist.gov/vuln/detail/CVE-2022-0235) | High (CVSS 8.2) | Exposure of sensitive information to an unauthorized actor — when following a redirect to a non-HTTP URL scheme (`file://`, `data://`, etc.), node-fetch would follow it and potentially leak sensitive host data |

Fixed in 2.6.8. This PR stays on the v2 line (rather than bumping to v3) because `functions/` uses CommonJS (`require()`), and node-fetch v3 is ESM-only.

## Change

```diff
- "node-fetch": "^2.6.7",
+ "node-fetch": "^2.6.13",
```

`^2.6.13` resolves to the latest patch release in the v2 series, picking up the CVE-2022-0235 fix and all subsequent patch fixes with no breaking changes.