### PR TITLE
chore(deps): bump firebase-admin in /functions from ^8.10.0 to ^12.0.0

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "cors": "^2.8.5",
-    "firebase-admin": "^8.10.0",
+    "firebase-admin": "^12.0.0",
     "firebase-functions": "^3.13.2",
     "firebase-tools": "^9.10.0",
     "node-fetch": "^2.6.7"


### PR DESCRIPTION
## Summary

Bumps `firebase-admin` in `functions/package.json` from `^8.10.0` to `^12.0.0`.

## Motivation

`firebase-admin` v8 reached end-of-life in 2021 and no longer receives security patches. Running an EOL version creates compounding risk through unmaintained transitive dependencies:

- **grpc** (bundled in v8) — multiple CVEs in older gRPC builds including memory-safety issues
- **google-auth-library** — v8 pulls an old version with known token-handling issues
- **protobufjs** — v8 depends on an older protobufjs range that includes CVE-2022-25878 (ReDoS) and CVE-2023-36665 (prototype pollution)

`firebase-admin` v12 is the current stable release and resolves these transitive dependency vulnerabilities.

## Change

```diff
- "firebase-admin": "^8.10.0",
+ "firebase-admin": "^12.0.0",
```

## Migration notes

v9–v12 introduce breaking changes in several areas:

- `admin.initializeApp()` no longer falls back to `GOOGLE_APPLICATION_CREDENTIALS` automatically in all environments — ensure the hosting environment sets this env var or passes a credential explicitly
- `admin.messaging()` → modular API (`getMessaging(app)`) preferred in v11+, though the legacy namespace still works in v12
- Node 18+ required (v12 dropped Node 14/16 support, which aligns with Firebase Functions gen2 runtime)

If the functions runtime is still gen1 (Node 12/14), this bump should be paired with a runtime upgrade; see [Firebase runtime documentation](https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version).